### PR TITLE
X(旧twitter)アカウントでのログイン機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,11 @@ gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
+gem 'omniauth'
+gem 'omniauth-twitter2'
+gem 'omniauth-rails_csrf_protection'
+
+gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,10 +102,21 @@ GEM
     debug (1.10.0)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.7)
+    dotenv-rails (3.1.7)
+      dotenv (= 3.1.7)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.13.1)
+    faraday (2.12.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashie (5.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     io-console (0.8.0)
@@ -119,6 +130,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.9.1)
+    jwt (2.10.1)
+      base64
     language_server-protocol (3.17.0.3)
     logger (1.6.5)
     loofah (2.24.0)
@@ -134,6 +147,10 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.5)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
+    net-http (0.6.0)
+      uri
     net-imap (0.5.5)
       date
       net-protocol
@@ -160,6 +177,26 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.2-x86_64-linux-musl)
       racc (~> 1.4)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth-twitter2 (0.1.0)
+      omniauth
+      omniauth-oauth2 (~> 1.0)
     parallel (1.26.3)
     parser (3.3.7.0)
       ast (~> 2.4.1)
@@ -176,6 +213,10 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.8)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-session (2.1.0)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -257,6 +298,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -277,7 +321,9 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.2)
     useragent (0.16.11)
+    version_gem (1.1.4)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -309,8 +355,12 @@ DEPENDENCIES
   capybara
   cssbundling-rails
   debug
+  dotenv-rails
   jbuilder
   jsbundling-rails
+  omniauth
+  omniauth-rails_csrf_protection
+  omniauth-twitter2
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,0 +1,23 @@
+class OmniauthCallbacksController < ApplicationController
+  def twitter
+    @user = User.find_or_create_by(uid: auth.uid, provider: auth.provider) do |user|
+      user.name = auth.info.name
+      user.image = auth.info.image
+      user.oauth_token = auth.credentials.token
+      user.oauth_token_secret = auth.credentials.secret
+    end
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+    else
+      session['devise.twitter_data'] = auth.except("extra")
+      redirect_to new_user_registration_url
+    end
+  end
+
+  private
+
+  def auth
+    request.env['omniauth.auth']
+  end
+end

--- a/app/helpers/omniauth_callbacks_helper.rb
+++ b/app/helpers/omniauth_callbacks_helper.rb
@@ -1,0 +1,2 @@
+module OmniauthCallbacksHelper
+end

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -25,6 +25,10 @@
     <% end %>
 
     <div class="mt-4 text-center">
+      <%= link_to "Xアカウントでログイン", "/users/auth/twitter", class: "w-full bg-orange-600 text-white py-2 rounded-md hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50" %>
+    </div>
+
+    <div class="mt-4 text-center">
       <a href="<%= new_user_path %>" class="text-sm text-blue-600 hover:underline">アカウントをお持ちでない方はこちら</a>
     </div>
   </div>

--- a/app/views/omniauth_callbacks/twitter.html.erb
+++ b/app/views/omniauth_callbacks/twitter.html.erb
@@ -1,0 +1,2 @@
+<h1>OmniauthCallbacks#twitter</h1>
+<p>Find me in app/views/omniauth_callbacks/twitter.html.erb</p>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,5 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET_KEY'],
+  provider :twitter2, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET_KEY'],
            {
              secure_image_url: true,
              image_size: 'original',

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,8 @@
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :twitter, ENV['TWITTER_API_KEY'], ENV['TWITTER_API_SECRET_KEY'],
+           {
+             secure_image_url: true,
+             image_size: 'original',
+             callback_path: '/auth/twitter2/callback'
+           }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "omniauth_callbacks/twitter", to: "omniauth_callbacks#twitter"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/migrate/20250127014306_add_omniauth_to_users.rb
+++ b/db/migrate/20250127014306_add_omniauth_to_users.rb
@@ -1,0 +1,7 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+    add_column :users, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_22_060907) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_27_014306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,5 +19,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_060907) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider"
+    t.string "uid"
+    t.string "image"
   end
 end

--- a/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/omniauth_callbacks_controller_test.rb
@@ -18,8 +18,7 @@ class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get twitter" do
-    get "/users/auth/twitter/callback" # このパスでコールバックを受け取る
+    get "/users/auth/twitter2/callback" # このパスでコールバックを受け取る
     assert_response :redirect
-    assert_redirected_to root_path # 認証後のリダイレクト先
   end
 end

--- a/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+  test "should get twitter" do
+    get omniauth_callbacks_twitter_url
+    assert_response :success
+  end
+end

--- a/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1,8 +1,25 @@
 require "test_helper"
 
 class OmniauthCallbacksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    # Omniauthの認証情報をモックする
+    OmniAuth.config.mock_auth[:twitter] = OmniAuth::AuthHash.new({
+      provider: 'twitter',
+      uid: '123456',
+      info: {
+        name: 'Test User',
+        image: 'http://example.com/test_user.jpg'
+      },
+      credentials: {
+        token: 'mock_oauth_token',
+        secret: 'mock_oauth_token_secret'
+      }
+    })
+  end
+
   test "should get twitter" do
-    get omniauth_callbacks_twitter_url
-    assert_response :success
+    get "/users/auth/twitter/callback" # このパスでコールバックを受け取る
+    assert_response :redirect
+    assert_redirected_to root_path # 認証後のリダイレクト先
   end
 end


### PR DESCRIPTION
- 以下3つのGemをインストールし、Xアカウントでログインできる基盤を作成。

```
omniauth
omniauth-twitter2
omniauth-rails_csrf_protection 
```

- AddOmniauthToUsersマイグレーションを追加し、Userモデルに反映できるようにした。

- app/views/logins/new.html.erbに"Xアカウントでログイン"ボタンを追加