### PR TITLE
カラコン管理ページの作成

### DIFF
--- a/app/controllers/contact_lenses_controller.rb
+++ b/app/controllers/contact_lenses_controller.rb
@@ -1,0 +1,48 @@
+class ContactLensesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_contact_lens, only: [:edit, :update, :destroy]
+
+  def index
+    @contact_lenses = ContactLens.all
+  end
+
+  def new
+    @contact_lens = ContactLens.new
+  end
+
+  def create
+    @contact_lens = ContactLens.new(contact_lens_params)
+    if @contact_lens.save
+      redirect_to contact_lenses_path, notice: "カラコンが登録されました"
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @contact_lens.update(contact_lens_params)
+      redirect_to contact_lenses_path, notice: "カラコンが更新されました"
+    else
+      flash.now[:alert] = '更新に失敗しました'
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @contact_lens.destroy
+    redirect_to contact_lenses_path, notice: "カラコンが削除されました"
+  end
+
+  private
+
+  def set_contact_lens
+    @contact_lens = ContactLens.find(params[:id])
+  end
+
+  def contact_lens_params
+    params.require(:contact_lens).permit(:name, :image, :expiration_date, :quantity, :memo)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def format_month_year(date)
+    date.strftime('%Y年%m月') if date.present?
+  end
 end

--- a/app/helpers/contact_lenses_helper.rb
+++ b/app/helpers/contact_lenses_helper.rb
@@ -1,0 +1,2 @@
+module ContactLensesHelper
+end

--- a/app/models/contact_lens.rb
+++ b/app/models/contact_lens.rb
@@ -1,9 +1,21 @@
 class ContactLens < ApplicationRecord
   self.table_name = 'contact_lenses'
+  before_save :set_expiration_date_to_beginning_of_month
 
   mount_uploader :image, ImageUploader
 
   private
+
+  def set_expiration_date_to_beginning_of_month
+  return unless expiration_date_before_type_cast.present?
+    
+    if expiration_date_before_type_cast.is_a?(String)
+      year, month = expiration_date_before_type_cast.split('-').map(&:to_i)
+      self.expiration_date = Date.new(year, month, 1)
+    end
+  rescue Date::Error
+    errors.add(:expiration_date, "は有効な日付ではありません")
+  end
 
   def image_size_validation
     if image.present? && image.size > 5.megabytes

--- a/app/models/contact_lens.rb
+++ b/app/models/contact_lens.rb
@@ -1,2 +1,13 @@
 class ContactLens < ApplicationRecord
+  self.table_name = 'contact_lenses'
+
+  mount_uploader :image, ImageUploader
+
+  private
+
+  def image_size_validation
+    if image.present? && image.size > 5.megabytes
+      errors.add(:image, "は5MB以下にしてください")
+    end
+  end
 end

--- a/app/views/contact_lenses/edit.html.erb
+++ b/app/views/contact_lenses/edit.html.erb
@@ -22,7 +22,7 @@
     <!-- 使用期限 -->
     <div>
       <%= form.label :expiration_date, "使用期限", class: "block text-sm font-medium text-gray-700" %>
-      <%= form.date_field :expiration_date, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+      <%= form.month_field :expiration_date, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
     </div>
 
     <!-- 枚数 -->

--- a/app/views/contact_lenses/edit.html.erb
+++ b/app/views/contact_lenses/edit.html.erb
@@ -1,0 +1,53 @@
+<h1 class="text-3xl font-semibold text-center mb-8">カラコン編集</h1>
+
+<%= form_with model: @contact_lens, url: contact_lense_path(@contact_lens), local: true, data: { turbo: false } do |form| %>
+  <div class="space-y-6">
+    <!-- カラコン画像 -->
+    <div>
+      <%= form.label :image, "画像", class: "block text-sm font-medium text-gray-700", accept: 'image/*' %>
+      <%= form.file_field :image, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+      <% if @contact_lens.image? %>
+        <div class="mt-2">
+          <img src="<%= @contact_lens.image.url %>" alt="現在の画像" class="w-32 h-32 object-cover">
+        </div>
+      <% end %>
+    </div>
+
+    <!-- カラコン名 -->
+    <div>
+      <%= form.label :name, "カラコン名", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.text_field :name, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- 使用期限 -->
+    <div>
+      <%= form.label :expiration_date, "使用期限", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.date_field :expiration_date, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- 枚数 -->
+    <div>
+      <%= form.label :quantity, "枚数", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.number_field :quantity, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- メモ -->
+    <div>
+      <%= form.label :memo, "メモ", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.text_area :memo, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- 更新ボタン -->
+    <div class="flex justify-end">
+      <%= form.submit '更新', class: "px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition" %>
+    </div>
+  </div>
+<% end %>
+
+<div class="mt-6 flex justify-center space-x-4">
+  <%= link_to '戻る', contact_lenses_path, class: "inline-block px-6 py-2 bg-gray-300 text-gray-800 rounded-lg hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 transition" %>
+
+  <%= link_to '削除', contact_lense_path(@contact_lens), 
+            data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' },
+            class: "inline-block px-6 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-500 transition" %>
+</div>

--- a/app/views/contact_lenses/index.html.erb
+++ b/app/views/contact_lenses/index.html.erb
@@ -18,7 +18,7 @@
       </div>
       <!-- 使用期限 -->
       <div class="p-4 text-sm text-gray-600">
-        <p><strong>使用期限:</strong> <%= contact_lens.expiration_date %></p>
+        <p><strong>使用期限:</strong> <%= format_month_year(contact_lens.expiration_date) %></p>
       </div>
     </div>
   <% end %>

--- a/app/views/contact_lenses/index.html.erb
+++ b/app/views/contact_lenses/index.html.erb
@@ -1,0 +1,30 @@
+<h1 class="text-3xl font-semibold text-center mb-8">カラコン一覧</h1>
+
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+  <% @contact_lenses.each do |contact_lens| %>
+    <div class="bg-white shadow-md rounded-lg overflow-hidden transition-transform transform hover:scale-105">
+      <!-- カラコンの画像 -->
+      <%= link_to edit_contact_lense_path(contact_lens) do %>
+        <% if contact_lens.image.present? %>
+          <%= image_tag contact_lens.image.url, alt: contact_lens.name, class: "w-full h-56 object-cover" %>
+        <% else %>
+          <%= image_tag 'no_image.jpg', alt: "画像なし", class: "w-full h-56 object-cover" %>
+        <% end %>
+      <% end %>
+
+      <!-- カラコンの名前 -->
+      <div class="p-4">
+        <%= link_to contact_lens.name, edit_contact_lense_path(contact_lens), class: "text-xl font-semibold text-gray-900 hover:text-blue-600" %>
+      </div>
+      <!-- 使用期限 -->
+      <div class="p-4 text-sm text-gray-600">
+        <p><strong>使用期限:</strong> <%= contact_lens.expiration_date %></p>
+      </div>
+    </div>
+  <% end %>
+</div>
+
+<div class="mt-8 flex justify-center space-x-4">
+  <%= link_to '新規登録', new_contact_lense_path, class: "px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition" %>
+  <%= link_to '戻る', root_path, class: "px-6 py-2 bg-gray-300 text-gray-800 rounded-lg hover:bg-gray-400 transition" %>
+</div>

--- a/app/views/contact_lenses/new.html.erb
+++ b/app/views/contact_lenses/new.html.erb
@@ -23,7 +23,7 @@
     <!-- 使用期限 -->
     <div>
       <%= form.label :expiration_date, "使用期限", class: "block text-sm font-medium text-gray-700" %>
-      <%= form.date_field :expiration_date, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+      <%= form.month_field :expiration_date, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
     </div>
 
     <!-- 枚数 -->

--- a/app/views/contact_lenses/new.html.erb
+++ b/app/views/contact_lenses/new.html.erb
@@ -1,0 +1,50 @@
+<%= form_with model: @contact_lens, url: contact_lenses_path, local: true, multipart: true, data: { turbo: false } do |form| %>
+  <div class="max-w-xl mx-auto bg-white p-6 rounded-lg shadow-md">
+    <h2 class="text-2xl font-semibold text-gray-800 mb-4">カラコンの登録</h2>
+
+  <div class="space-y-6">
+    <!-- カラコン画像 -->
+    <div>
+      <%= form.label :image, "画像", class: "block text-gray-700" %>
+      <%= form.file_field :image, class: "mt-1 block w-full text-gray-800", accept: "image/*" %>
+      <% if @contact_lens.image.present? %>
+        <div class="mt-4">
+          <%= image_tag @contact_lens.image.url, class: "max-w-xs" %>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- カラコン名 -->
+    <div>
+      <%= form.label :name, "カラコン名", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.text_field :name, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- 使用期限 -->
+    <div>
+      <%= form.label :expiration_date, "使用期限", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.date_field :expiration_date, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- 枚数 -->
+    <div>
+      <%= form.label :quantity, "枚数", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.number_field :quantity, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- メモ -->
+    <div>
+      <%= form.label :memo, "メモ", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.text_area :memo, class: "mt-1 block w-full text-gray-900 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500" %>
+    </div>
+
+    <!-- 登録ボタン -->
+    <div class="flex justify-end">
+      <%= form.submit '登録する', class: "px-6 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 transition" %>
+    </div>
+  </div>
+<% end %>
+
+<div class="mt-6 flex justify-center space-x-4">
+  <%= link_to '戻る', contact_lenses_path, class: "inline-block px-6 py-2 bg-gray-300 text-gray-800 rounded-lg hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 transition" %>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -16,7 +16,7 @@
         </div>
       <% end %>
 
-      <%= link_to contactlenses_path, class: "block" do %>
+      <%= link_to contact_lenses_path, class: "block" do %>
         <div class="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition duration-300">
           <div class="text-xl font-semibold text-center">カラコン</div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 
   resources :costumes, only: [:index, :new, :create, :edit, :update, :destroy]
   resources :wigs
-  resources :contactlenses
+  resources :contact_lenses
   resources :tasks
   resources :articles
   resources :settings

--- a/test/controllers/contact_lenses_controller_test.rb
+++ b/test/controllers/contact_lenses_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ContactLensesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
カラコン管理ページのCRUD操作を実装。

- カラコン一覧画面(app/views/contact_lenses/index.html.erb)
  - 画像・カラコン名・使用期限を表示
- カラコン新規登録(app/views/contact_lenses/new.html.erb)
- カラコン編集・削除(app/views/contact_lenses/edit.html.erb)

※ 使用期限は「年/月」での登録