### PR TITLE
記事一覧ページ

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,0 +1,7 @@
+class ArticlesController < ApplicationController
+  def index
+    @articles = Article.all
+    # プロフィールを作成後にコメントアウトを外す
+    # @articles = Article.includes(:user)
+  end
+end

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,0 +1,2 @@
+module ArticlesHelper
+end

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,0 +1,40 @@
+<div class="min-h-screen bg-gray-100">
+  <div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-semibold text-center mb-8">記事一覧</h1>
+
+    <!-- 記事がない場合 -->
+    <% if @articles.empty? %>
+      <div class="text-center text-lg text-gray-500">
+        記事がありません
+      </div>
+    <% else %>
+      <!-- 記事一覧 -->
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+        <% @articles.each do |article| %>
+          <div class="bg-white rounded-lg shadow-md overflow-hidden">
+            <%= link_to article_path(article), class: "block hover:shadow-lg transition duration-300" do %>
+              <div class="p-6">
+                <h2 class="text-xl font-bold mb-4 text-gray-800">
+                  <%= article.title %>
+                </h2>
+                <p class="text-gray-600 text-sm mb-4">
+                  <%= truncate(article.content, length: 100) %>
+                </p>
+                <div class="text-sm text-gray-500">
+                  <%= time_ago_in_words(article.created_at) %> 前に投稿
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+
+  <!-- スクロールしても見える「記事を作成」ボタン -->
+  <div class="fixed bottom-8 right-8">
+    <%= link_to new_article_path, class: "bg-blue-600 text-white py-2 px-4 rounded-lg shadow-lg hover:bg-blue-700 transition duration-300" do %>
+      記事を作成
+    <% end %>
+  </div>
+</div>

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ArticlesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
記事の一覧ページを実装。

- ログイン必要なし
- 記事がない場合は「記事がありません」表示
- 記事の新規作成ボタンを下部に配置。
  - スクロールしても位置を固定