### PR TITLE
やることページの編集・削除機能

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -53,7 +53,11 @@ class TasksController < ApplicationController
 
   def destroy
     @task.destroy
-    redirect_to tasks_path
+  
+    respond_to do |format|
+      format.html { redirect_to tasks_path }
+      format.turbo_stream { render turbo_stream: turbo_stream.remove("task_#{@task.id}") }
+    end
   end
 
   def toggle

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -61,7 +61,6 @@ class TasksController < ApplicationController
   end
 
   def toggle
-    @task = current_user.tasks.find(params[:id])
     @task.update(completed: !@task.completed)
 
     respond_to do |format|

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,39 +1,68 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_task, only: [:update, :destroy, :toggle]
+  before_action :set_task, only: [:edit, :update, :destroy, :toggle]
 
   def index
     @tasks = current_user.tasks.order(due_date: :asc)
     @task = Task.new
   end
 
+  def new
+    @task = Task.new
+  end
+
   def create
     @task = current_user.tasks.new(task_params)
 
-    if @task.save
-      redirect_to tasks_path, notice: 'やることを作成しました'
-    else
-      @tasks = current_user.tasks.order(due_date: :asc)
-      render :index
+    respond_to do |format|
+      if @task.save
+        format.turbo_stream do
+          render turbo_stream: [
+            turbo_stream.append('tasks', partial: 'tasks/task', locals: { task: @task }),
+            turbo_stream.replace('modal', '')  # モーダルを閉じる
+          ]
+        end
+      else
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace('task-form', partial: 'tasks/form', locals: { task: @task })
+        end
+      end
     end
   end
 
+  def edit
+    render layout: false
+  end
+
   def update
-    if @task.update(task_params)
-      redirect_to tasks_path, notice: '更新しました'
-    else
-      render :edit
+    respond_to do |format|
+      if @task.update(task_params)
+        format.turbo_stream do
+          render turbo_stream: [
+            turbo_stream.replace("task_#{@task.id}", partial: 'tasks/task', locals: { task: @task }),
+            turbo_stream.replace('modal', '')  # モーダルを閉じる
+          ]
+        end
+      else
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace('task-form', partial: 'tasks/form', locals: { task: @task })
+        end
+      end
     end
   end
 
   def destroy
     @task.destroy
-    redirect_to tasks_path, notice: 'やることを削除しました'
+    redirect_to tasks_path
   end
 
   def toggle
+    @task = current_user.tasks.find(params[:id])
     @task.update(completed: !@task.completed)
-    redirect_to tasks_path
+
+    respond_to do |format|
+      format.turbo_stream
+    end
   end
 
   private

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,49 +1,40 @@
-import { Controller } from "@hotwired/stimulus";
+import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="review-modal"
 export default class extends Controller {
-  // ターゲットの定義
-  static targets = ["modal", "backGround"];
+  static targets = ["modal", "backGround"]
 
-  // connectメソッドは、コントローラに繋がれた時に呼ばれる
   connect() {
-    // 初期化や追加処理があればここに書きます（今回は特にありません）
+    // モーダルを表示状態にする
+    this.openModal()
   }
 
-  // フォームが送信されたときのアクション
-  close(event) {
-    // event.detail.success はレスポンスが成功なら true を返します
-    if (event.detail.success) {
-      // 成功時、モーダルを閉じる
-      this.closeModal();
-    } else {
-      // バリデーションエラーがあった場合
-      this.showValidationError();
+  closeModal(event) {
+    if (event) {
+      event.preventDefault()
     }
+    this.element.remove()
   }
 
-  // モーダルを閉じる
-  closeModal() {
-    this.modalTarget.classList.add("hidden");
-    this.backGroundTarget.classList.add("hidden");
-  }
-
-  // モーダルの外をクリックした際に閉じる
   closeBackground(event) {
     if (event.target === this.backGroundTarget) {
-      this.closeModal();
+      this.closeModal()
     }
   }
 
-  // モーダルを開く
   openModal() {
-    this.modalTarget.classList.remove("hidden");
-    this.backGroundTarget.classList.remove("hidden");
+    this.modalTarget.classList.remove("hidden")
+    this.backGroundTarget.classList.remove("hidden")
   }
 
-  // バリデーションエラーがある場合の処理
+  close(event) {
+    if (event.detail.success) {
+      this.closeModal()
+    } else {
+      this.showValidationError()
+    }
+  }
+
   showValidationError() {
-    alert("フォームにエラーがあります。もう一度確認してください。");
-    // 必要に応じてバリデーションエラーを表示する処理を追加できます
+    alert("フォームにエラーがあります。もう一度確認してください。")
   }
 }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,49 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="review-modal"
+export default class extends Controller {
+  // ターゲットの定義
+  static targets = ["modal", "backGround"];
+
+  // connectメソッドは、コントローラに繋がれた時に呼ばれる
+  connect() {
+    // 初期化や追加処理があればここに書きます（今回は特にありません）
+  }
+
+  // フォームが送信されたときのアクション
+  close(event) {
+    // event.detail.success はレスポンスが成功なら true を返します
+    if (event.detail.success) {
+      // 成功時、モーダルを閉じる
+      this.closeModal();
+    } else {
+      // バリデーションエラーがあった場合
+      this.showValidationError();
+    }
+  }
+
+  // モーダルを閉じる
+  closeModal() {
+    this.modalTarget.classList.add("hidden");
+    this.backGroundTarget.classList.add("hidden");
+  }
+
+  // モーダルの外をクリックした際に閉じる
+  closeBackground(event) {
+    if (event.target === this.backGroundTarget) {
+      this.closeModal();
+    }
+  }
+
+  // モーダルを開く
+  openModal() {
+    this.modalTarget.classList.remove("hidden");
+    this.backGroundTarget.classList.remove("hidden");
+  }
+
+  // バリデーションエラーがある場合の処理
+  showValidationError() {
+    alert("フォームにエラーがあります。もう一度確認してください。");
+    // 必要に応じてバリデーションエラーを表示する処理を追加できます
+  }
+}

--- a/app/javascript/controllers/task_toggle_controller.js
+++ b/app/javascript/controllers/task_toggle_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["checkbox", "status"]
+  static values = { taskId: Number }
+
+  toggle() {
+    const url = `/tasks/${this.taskIdValue}/toggle`
+    fetch(url, {
+      method: 'PATCH',
+      headers: {
+        'X-CSRF-Token': document.querySelector("[name='csrf-token']").content,
+        'Accept': 'text/vnd.turbo-stream.html'
+      },
+      credentials: 'same-origin'
+    })
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,6 @@
     <script src="https://cdn.jsdelivr.net/npm/trix@2.0.0/dist/trix.js"></script>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%= turbo_frame_tag 'modal' %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', type: "module" %>
   </head>
@@ -33,6 +32,7 @@
 
     <div class="container mx-auto p-4">
       <%= yield %>
+      <%= turbo_frame_tag 'modal' %>
     </div>
 
     <footer class="bg-white-800 text-gray py-6">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <script src="https://cdn.jsdelivr.net/npm/trix@2.0.0/dist/trix.js"></script>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= turbo_frame_tag 'modal' %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload', type: "module" %>
   </head>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,0 +1,12 @@
+<div class="task-item" id="task_<%= task.id %>">
+  <h3 class="text-xl font-semibold"><%= task.title %></h3>
+  <p class="text-gray-500"><%= task.description %></p>
+  <p class="text-sm text-gray-400">期限: <%= task.due_date %></p>
+  <div class="flex gap-2">
+    <% if task.completed? %>
+      <span class="text-green-500">完了</span>
+    <% else %>
+      <span class="text-red-500">未完了</span>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,44 +1,58 @@
-<div class="task-item border p-4 mb-4 rounded-lg shadow" id="task_<%= task.id %>" data-controller="task-toggle" data-task-toggle-task-id-value="<%= task.id %>">
-  <div class="flex justify-between items-start">
-    <div class="flex-1">
-      <div class="flex items-center gap-3 mb-2">
-        <%= check_box_tag nil, nil, task.completed,
-            class: "h-5 w-5 rounded border-gray-300",
-            data: {
-              task_toggle_target: "checkbox",
-              action: "change->task-toggle#toggle"
-            } %>
+<%= turbo_frame_tag dom_id(task) do %>
+  <div class="task-item border p-4 mb-4 rounded-lg shadow hover:shadow-md transition-shadow duration-200 <%= task.completed ? 'bg-gray-50' : 'bg-white' %>"
+       data-controller="task-toggle"
+       data-task-toggle-task-id-value="<%= task.id %>">
+    <div class="flex justify-between items-start">
+      <div class="flex-1">
+        <div class="flex items-center gap-3 mb-2">
+          <%= check_box_tag nil, nil, task.completed,
+              class: "h-5 w-5 rounded border-gray-300 cursor-pointer focus:ring-2 focus:ring-blue-500",
+              data: {
+                task_toggle_target: "checkbox",
+                action: "change->task-toggle#toggle"
+              } %>
+          
+          <h3 class="text-xl font-semibold <%= task.completed ? 'line-through text-gray-500' : 'text-gray-900' %>">
+            <%= task.title %>
+          </h3>
+        </div>
         
-        <h3 class="text-xl font-semibold <%= task.completed ? 'line-through text-gray-500' : '' %>">
-          <%= task.title %>
-        </h3>
+        <% if task.description.present? %>
+          <p class="text-gray-600 mb-2 <%= task.completed ? 'text-gray-400' : '' %>">
+            <%= task.description %>
+          </p>
+        <% end %>
+
+        <div class="flex items-center gap-2 text-sm text-gray-500">
+          <i class="far fa-calendar-alt"></i>
+          <span class="<%= 'text-red-500 font-semibold' if task.due_date&.past? && !task.completed %>">
+            <%= task.due_date&.strftime("%Y年%m月%d日") || '期限なし' %>
+          </span>
+        </div>
       </div>
-      
-      <p class="text-gray-600 mb-2"><%= task.description %></p>
-      <p class="text-sm text-gray-500">期限: <%= task.due_date&.strftime("%Y年%m月%d日") %></p>
-    </div>
 
-    <div class="flex gap-2">
-      <%= link_to edit_task_path(task),
-          data: { 
-            controller: "modal",
-            action: "click->modal#open",
-            turbo_frame: "modal"
-          },
-          class: "text-blue-500 hover:text-blue-700" do %>
-        <i class="fas fa-edit"></i> 編集
-      <% end %>
+      <div class="flex gap-2">
+        <%= link_to edit_task_path(task),
+            data: { 
+              turbo_frame: "modal"
+            },
+            class: "inline-flex items-center px-3 py-1 text-sm text-blue-600 hover:text-blue-800 transition-colors duration-150" do %>
+          <i class="fas fa-edit mr-1"></i>
+          <span>編集</span>
+        <% end %>
 
-      <%= button_to task_path(task),
-          method: :delete,
-          data: { 
-            turbo_confirm: "本当に削除しますか？",
-            turbo_frame: "tasks"
-          },
-          class: "text-red-500 hover:text-red-700",
-          form: { class: "inline-block" } do %>
-        <i class="fas fa-trash"></i> 削除
-      <% end %>
+        <%= button_to task_path(task),
+            method: :delete,
+            data: { 
+              turbo_confirm: "このタスクを削除してもよろしいですか？",
+              turbo_frame: "_top"
+            },
+            class: "inline-flex items-center px-3 py-1 text-sm text-red-600 hover:text-red-800 transition-colors duration-150",
+            form: { class: "inline-block" } do %>
+          <i class="fas fa-trash-alt mr-1"></i>
+          <span>削除</span>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,12 +1,48 @@
-<div class="task-item" id="task_<%= task.id %>">
-  <h3 class="text-xl font-semibold"><%= task.title %></h3>
-  <p class="text-gray-500"><%= task.description %></p>
-  <p class="text-sm text-gray-400">期限: <%= task.due_date %></p>
-  <div class="flex gap-2">
-    <% if task.completed? %>
-      <span class="text-green-500">完了</span>
-    <% else %>
-      <span class="text-red-500">未完了</span>
-    <% end %>
+<div class="task-item border p-4 mb-4 rounded-lg shadow" id="task_<%= task.id %>" data-controller="task-toggle" data-task-toggle-task-id-value="<%= task.id %>">
+  <div class="flex justify-between items-start">
+    <div class="flex-1">
+      <div class="flex items-center gap-3 mb-2">
+        <%= check_box_tag nil, nil, task.completed,
+            class: "h-5 w-5 rounded border-gray-300",
+            data: {
+              task_toggle_target: "checkbox",
+              action: "change->task-toggle#toggle"
+            } %>
+        
+        <h3 class="text-xl font-semibold <%= task.completed ? 'line-through text-gray-500' : '' %>">
+          <%= task.title %>
+        </h3>
+        
+        <span class="px-2 py-1 text-sm rounded-full <%= task.completed ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800' %>">
+          <%= task.completed ? '完了' : '未完了' %>
+        </span>
+      </div>
+      
+      <p class="text-gray-600 mb-2"><%= task.description %></p>
+      <p class="text-sm text-gray-500">期限: <%= task.due_date&.strftime("%Y年%m月%d日") %></p>
+    </div>
+
+    <div class="flex gap-2">
+      <%= link_to edit_task_path(task),
+          data: { 
+            controller: "modal",
+            action: "click->modal#open",
+            turbo_frame: "modal"
+          },
+          class: "text-blue-500 hover:text-blue-700" do %>
+        <i class="fas fa-edit"></i> 編集
+      <% end %>
+
+      <%= button_to task_path(task),
+          method: :delete,
+          data: { 
+            turbo_confirm: "本当に削除しますか？",
+            turbo_frame: "tasks"
+          },
+          class: "text-red-500 hover:text-red-700",
+          form: { class: "inline-block" } do %>
+        <i class="fas fa-trash"></i> 削除
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -12,10 +12,6 @@
         <h3 class="text-xl font-semibold <%= task.completed ? 'line-through text-gray-500' : '' %>">
           <%= task.title %>
         </h3>
-        
-        <span class="px-2 py-1 text-sm rounded-full <%= task.completed ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800' %>">
-          <%= task.completed ? '完了' : '未完了' %>
-        </span>
       </div>
       
       <p class="text-gray-600 mb-2"><%= task.description %></p>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag "modal" do %>
-  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="backGround" data-action="click->review-modal#closeBackground">
-    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-review-modal-target="reviewModal">
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="modal" data-modal-target="backGround" data-action="click->modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-modal-target="modal">
       <div class="flex justify-end items-center">
-        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->review-modal#closeModal"></i>
+        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->modal#closeModal"></i>
       </div>
 
       <%= form_with model: @task, data: { action: "turbo:submit-end->modal#close" }, method: :put do |f| %>
@@ -22,6 +22,9 @@
         </div>
 
         <div class="flex justify-end gap-2">
+          <%= link_to "キャンセル", "#", 
+              class: "bg-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-400", 
+              data: { action: "click->modal#closeModal" } %>
           <%= f.submit "保存", class: "bg-blue-500 text-white px-4 py-2 rounded" %>
         </div>
       <% end %>     

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,30 @@
+<%= turbo_frame_tag "modal" do %>
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="backGround" data-action="click->review-modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-review-modal-target="reviewModal">
+      <div class="flex justify-end items-center">
+        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->review-modal#closeModal"></i>
+      </div>
+
+      <%= form_with model: @task, data: { action: "turbo:submit-end->modal#close" }, method: :put do |f| %>
+        <div class="mb-4">
+          <%= f.label :title, "タイトル", class: "block mb-2" %>
+          <%= f.text_field :title, class: "w-full border rounded px-3 py-2" %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :description, "説明", class: "block mb-2" %>
+          <%= f.text_area :description, class: "w-full border rounded px-3 py-2" %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :due_date, "期限", class: "block mb-2" %>
+          <%= f.date_field :due_date, class: "w-full border rounded px-3 py-2" %>
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <%= f.submit "保存", class: "bg-blue-500 text-white px-4 py-2 rounded" %>
+        </div>
+      <% end %>     
+    </div>
+  </div>
+<% end %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,82 +1,8 @@
-<div class="min-h-screen bg-gray-100">
-  <div class="container mx-auto px-4 py-8">
-    <div class="max-w-4xl mx-auto">
-      <div class="flex justify-between items-center mb-6">
-        <h1 class="text-2xl font-bold">ToDo リスト</h1>
-        <button class="bg-blue-500 text-white px-4 py-2 rounded-lg"
-                onclick="document.getElementById('new-task-modal').classList.remove('hidden')">
-          新規タスク作成
-        </button>
-      </div>
+<div class="container mx-auto px-4">
+  <h1 class="text-2xl font-bold mb-4">タスク一覧</h1>
+  <%= link_to "新規タスク作成", new_task_path, class: "bg-blue-500 text-white px-4 py-2 rounded", data: { turbo_frame: 'modal' } %>
 
-      <!-- タスク一覧 -->
-      <div class="bg-white rounded-lg shadow p-6">
-        <% @tasks.each do |task| %>
-          <div class="flex items-center justify-between py-3 border-b last:border-0">
-            <div class="flex items-center space-x-3">
-              <%= button_to toggle_task_path(task), method: :patch, class: "flex items-center" do %>
-                <div class="w-6 h-6 border-2 rounded-full <%= task.completed? ? 'bg-green-500 border-green-500' : 'border-gray-400' %>"></div>
-              <% end %>
-              <div class="<%= task.completed? ? 'line-through text-gray-500' : '' %>">
-                <div class="font-medium"><%= task.title %></div>
-                <div class="text-sm text-gray-600"><%= task.description %></div>
-                <% if task.due_date %>
-                  <div class="text-sm text-gray-500">期限: <%= task.due_date.strftime("%Y/%m/%d %H:%M") %></div>
-                <% end %>
-              </div>
-            </div>
-            <div class="flex space-x-2">
-              <button onclick="openEditModal('<%= task.id %>')" class="text-blue-500">
-                <i class="fas fa-edit"></i>
-              </button>
-              <%= button_to task_path(task), method: :delete, class: "text-red-500", data: { confirm: "本当に削除しますか？" } do %>
-                <i class="fas fa-trash"></i>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </div>
-
-      <!-- 戻るボタン -->
-      <div class="mt-8 text-center">
-        <%= link_to task_selection_path, class: "inline-block bg-gray-500 text-white px-6 py-2 rounded-lg hover:bg-gray-600 transition duration-300" do %>
-          <i class="fas fa-arrow-left mr-2"></i>戻る
-        <% end %>
-      </div>
-
-      <!-- 新規タスク作成モーダル -->
-      <div id="new-task-modal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full">
-        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
-          <div class="mt-3">
-            <h3 class="text-lg font-medium text-gray-900 mb-4">新規タスク作成</h3>
-            <%= form_with(model: @task, local: true) do |f| %>
-              <div class="mb-4">
-                <%= f.label :title, "タイトル", class: "block text-sm font-medium text-gray-700" %>
-                <%= f.text_field :title, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50" %>
-              </div>
-
-              <div class="mb-4">
-                <%= f.label :description, "詳細", class: "block text-sm font-medium text-gray-700" %>
-                <%= f.text_area :description, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50" %>
-              </div>
-
-              <div class="mb-4">
-                <%= f.label :due_date, "期限", class: "block text-sm font-medium text-gray-700" %>
-                <%= f.datetime_field :due_date, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50" %>
-              </div>
-
-              <div class="flex justify-end space-x-2">
-                <button type="button" class="bg-gray-500 text-white px-4 py-2 rounded-lg"
-                        onclick="document.getElementById('new-task-modal').classList.add('hidden')">
-                  キャンセル
-                </button>
-                <%= f.submit "作成", class: "bg-blue-500 text-white px-4 py-2 rounded-lg" %>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>
-
-    </div>
+  <div id="tasks" class="task-list">
+    <%= render @tasks %>
   </div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,8 +1,11 @@
 <div class="container mx-auto px-4">
   <h1 class="text-2xl font-bold mb-4">タスク一覧</h1>
+
   <%= link_to "新規タスク作成", new_task_path, class: "bg-blue-500 text-white px-4 py-2 rounded", data: { turbo_frame: 'modal' } %>
 
   <div id="tasks" class="task-list">
-    <%= render @tasks %>
+    <% @tasks.each do |task| %>
+      <%= render 'tasks/task', task: task %>
+    <% end %>
   </div>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -25,4 +25,5 @@
       <i class="fas fa-arrow-left mr-2"></i>戻る
     <% end %>
   </div>
+  <%= turbo_frame_tag 'modal' %>
 </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,11 +1,28 @@
 <div class="container mx-auto px-4">
-  <h1 class="text-2xl font-bold mb-4">タスク一覧</h1>
-
-  <%= link_to "新規タスク作成", new_task_path, class: "bg-blue-500 text-white px-4 py-2 rounded", data: { turbo_frame: 'modal' } %>
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold">タスク一覧</h1>
+    <%= link_to new_task_path,
+        class: "inline-flex items-center bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg transition duration-150 ease-in-out shadow-md",
+        data: { turbo_frame: 'modal' } do %>
+      新規タスク作成
+    <% end %>
+  </div>
 
   <div id="tasks" class="task-list">
-    <% @tasks.each do |task| %>
-      <%= render 'tasks/task', task: task %>
+    <% if @tasks.any? %>
+      <% @tasks.each do |task| %>
+        <%= render 'tasks/task', task: task %>
+      <% end %>
+    <% else %>
+      <div class="text-center py-8 text-gray-500">
+        <p>タスクがありません。新規タスクを作成してください。</p>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="text-center">
+    <%= link_to task_selection_path, class: "inline-block bg-gray-500 text-white px-6 py-2 rounded-lg hover:bg-gray-600 transition duration-300" do %>
+      <i class="fas fa-arrow-left mr-2"></i>戻る
     <% end %>
   </div>
 </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag "modal" do %>
-  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="backGround" data-action="click->review-modal#closeBackground">
-    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-review-modal-target="modal">
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="modal" data-modal-target="backGround" data-action="click->modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-modal-target="modal">
       <div class="flex justify-end items-center">
-        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->review-modal#closeModal"></i>
+        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->modal#closeModal"></i>
       </div>
-      <%= form_with model: @task, url: tasks_path, method: :post, data: { action: "turbo:submit-end->review-modal#close" } do |f| %>
+      <%= form_with model: @task, url: tasks_path, method: :post, data: { action: "turbo:submit-end->modal#close" } do |f| %>
         <div class="mb-4">
           <%= f.label :title, "タイトル", class: "block mb-2" %>
           <%= f.text_field :title, class: "w-full border rounded px-3 py-2" %>
@@ -20,6 +20,9 @@
           <%= f.date_field :due_date, class: "w-full border rounded px-3 py-2" %>
         </div>
         <div class="flex justify-end gap-2">
+          <%= link_to "キャンセル", "#", 
+              class: "bg-gray-300 text-gray-700 px-4 py-2 rounded hover:bg-gray-400", 
+              data: { action: "click->modal#closeModal" } %>
           <%= f.submit "保存", class: "bg-blue-500 text-white px-4 py-2 rounded" %>
         </div>
       <% end %>     

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,28 @@
+<%= turbo_frame_tag "modal" do %>
+  <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="backGround" data-action="click->review-modal#closeBackground">
+    <div class="modal-content bg-white rounded-xl shadow-lg p-10 w-18 md:w-[450px]" data-review-modal-target="modal">
+      <div class="flex justify-end items-center">
+        <i class="fa-solid fa-xmark h-6 w-6 hover:text-yellow-500" data-action="click->review-modal#closeModal"></i>
+      </div>
+      <%= form_with model: @task, url: tasks_path, method: :post, data: { action: "turbo:submit-end->review-modal#close" } do |f| %>
+        <div class="mb-4">
+          <%= f.label :title, "タイトル", class: "block mb-2" %>
+          <%= f.text_field :title, class: "w-full border rounded px-3 py-2" %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :description, "説明", class: "block mb-2" %>
+          <%= f.text_area :description, class: "w-full border rounded px-3 py-2" %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :due_date, "期限", class: "block mb-2" %>
+          <%= f.date_field :due_date, class: "w-full border rounded px-3 py-2" %>
+        </div>
+        <div class="flex justify-end gap-2">
+          <%= f.submit "保存", class: "bg-blue-500 text-white px-4 py-2 rounded" %>
+        </div>
+      <% end %>     
+    </div>
+  </div>
+<% end %>

--- a/app/views/tasks/toggle.turbo_stream.erb
+++ b/app/views/tasks/toggle.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace @task do %>
+  <%= render partial: "tasks/task", locals: { task: @task } %>
+<% end %>

--- a/app/views/tasks/toggle.turbo_stream.erb
+++ b/app/views/tasks/toggle.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace @task do %>
+<%= turbo_stream.replace "task_#{@task.id}" do %>
   <%= render partial: "tasks/task", locals: { task: @task } %>
 <% end %>


### PR DESCRIPTION
やることページの編集・削除機能の実装

- TurboとStimulusを使用したモーダルウィンドウに変更

- やることの編集と削除ができる

- モーダルにキャンセルボタンを追加