### PR TITLE
ボタン色とリストの修正

### DIFF
--- a/app/views/contact_lenses/edit.html.erb
+++ b/app/views/contact_lenses/edit.html.erb
@@ -58,7 +58,7 @@
 
         <!-- 更新ボタン -->
         <div class="flex flex-col items-center space-y-4 mt-12">
-          <%= form.submit "更新する", class: "w-full sm:w-2/3 px-8 py-4 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 text-center text-lg font-medium" %>
+          <%= form.submit "更新する", class: "w-full sm:w-2/3 px-8 py-4 bg-[#F4A489] text-white rounded-full hover:bg-[#f59577] transition-all duration-300 text-center text-lg font-medium" %>
           
           <!-- 戻るボタン -->
           <div class="w-full flex justify-center mt-6">

--- a/app/views/contact_lenses/index.html.erb
+++ b/app/views/contact_lenses/index.html.erb
@@ -42,7 +42,7 @@
       </svg>
       戻る
     <% end %>
-    <%= link_to new_contact_lense_path, class: "px-8 py-3 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
+    <%= link_to new_contact_lense_path, class: "px-8 py-3 bg-[#F4A489] text-white rounded-full hover:bg-[#f59577] transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
       </svg>

--- a/app/views/contact_lenses/new.html.erb
+++ b/app/views/contact_lenses/new.html.erb
@@ -59,7 +59,7 @@
             戻る
           <% end %>
 
-          <%= form.submit "登録する", class: "w-full sm:w-auto px-8 py-4 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 text-center text-lg font-medium" %>
+          <%= form.submit "登録する", class: "w-full sm:w-auto px-8 py-4 bg-[#F4A489] text-white rounded-full hover:bg-[#f59577] transition-all duration-300 text-center text-lg font-medium" %>
         </div>
       </div>
     <% end %>

--- a/app/views/packing_lists/edit.html.erb
+++ b/app/views/packing_lists/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="min-h-screen bg-white py-8 pb-12">
   <div class="max-w-2xl mx-auto px-4">
-    <h1 class="text-3xl font-semibold text-center mb-8" style="color: rgba(242, 210, 114, 0.75)">持ち物リストの編集</h1>
+    <h1 class="text-3xl font-semibold text-center mb-8" style="color: #FFB800">持ち物リストの編集</h1>
 
     <%= form_with(model: @packing_list, local: true, class: "bg-white shadow-lg rounded-2xl p-6 border", style: "border-color: rgba(242, 210, 114, 0.25)") do |f| %>
       <% if @packing_list.errors.any? %>
@@ -92,7 +92,7 @@
           戻る
         <% end %>
 
-        <%= f.submit "更新する", class: "px-8 py-3 text-white rounded-full transition-all duration-300 shadow-sm hover:shadow", style: "background-color: rgba(242, 210, 114, 0.75)" %>
+        <%= f.submit "更新する", class: "px-8 py-3 bg-[#FFB800] text-white rounded-full hover:bg-[#FFA500] transition-all duration-300 shadow-sm hover:shadow" %>
       </div>
     <% end %>
   </div>

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -1,9 +1,9 @@
 <div class="pb-24 bg-white">
-  <h1 class="text-3xl font-semibold text-center mb-8" style="color: rgba(242, 210, 114, 0.75)">持ち物リスト</h1>
+<h1 class="text-3xl font-semibold text-center mb-8" style="color: #FFB800">持ち物リスト</h1>
 
   <div class="max-w-3xl mx-auto px-4">
     <!-- リスト -->
-    <div class="bg-white shadow-lg rounded-2xl overflow-hidden border mb-4" style="border-color: rgba(242, 210, 114, 0.25)">
+    <div class="bg-white shadow-lg rounded-2xl overflow-hidden border mb-4" style="border-color: rgba(255, 184, 0, 0.25)">
       <ul class="divide-y divide-gray-200">
         <% @packing_lists.each do |list| %>
           <li class="hover:bg-gray-50 transition-colors duration-200">
@@ -14,7 +14,7 @@
                   <div class="mr-4">
                     <%= f.check_box :packed,
                         class: "h-6 w-6 rounded border-gray-300 focus:ring-2 cursor-pointer",
-                        style: "color: rgba(242, 210, 114, 0.75)",
+                        style: "color: #FFB800",
                         onchange: 'this.form.submit()' %>
                   </div>
                 <% end %>
@@ -83,7 +83,7 @@
       </svg>
       戻る
     <% end %>
-    <%= link_to new_packing_list_path, class: "px-8 py-3 text-white rounded-full transition-all duration-300 shadow-sm hover:shadow flex items-center", style: "background-color: rgba(242, 210, 114, 0.75)" do %>
+    <%= link_to new_packing_list_path, class: "px-8 py-3 bg-[#FFB800] text-white rounded-full hover:bg-[#FFA500] transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
       </svg>

--- a/app/views/packing_lists/index.html.erb
+++ b/app/views/packing_lists/index.html.erb
@@ -42,16 +42,16 @@
               <!-- 編集・削除ボタン -->
               <div class="flex items-center space-x-2">
                 <%= link_to edit_packing_list_path(list), 
-                    class: "p-2 hover:bg-gray-100 rounded-lg transition-colors duration-200 flex items-center",
+                    class: "p-2 hover:bg-[#FFECD1] rounded-lg transition-colors duration-200 flex items-center",
                     title: "編集" do %>
-                  <svg class="h-5 w-5" style="color: rgba(242, 210, 114, 0.75)" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg class="h-5 w-5" style="color: #FFB800" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
                   </svg>
                 <% end %>
 
                 <%= button_to packing_list_path(list), 
                     method: :delete,
-                    class: "p-2 hover:bg-gray-100 rounded-lg transition-colors duration-200 flex items-center",
+                    class: "p-2 hover:bg-red-50 rounded-lg transition-colors duration-200 flex items-center",
                     title: "削除",
                     data: { turbo_confirm: "本当に削除しますか？" } do %>
                   <svg class="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/views/packing_lists/new.html.erb
+++ b/app/views/packing_lists/new.html.erb
@@ -1,8 +1,8 @@
 <div class="min-h-screen bg-white py-8 pb-12">
   <div class="max-w-2xl mx-auto px-4">
-    <h1 class="text-3xl font-semibold text-center mb-8" style="color: rgba(242, 210, 114, 0.75)">アイテム登録</h1>
+    <h1 class="text-3xl font-semibold text-center mb-8" style="color: #FFB800">アイテム登録</h1>
 
-    <%= form_with(model: @packing_list, local: true, class: "bg-white shadow-lg rounded-2xl p-6 border", style: "border-color: rgba(242, 210, 114, 0.25)") do |f| %>
+    <%= form_with(model: @packing_list, local: true, class: "bg-white shadow-lg rounded-2xl p-6 border", style: "border-color: rgba(255, 184, 0, 0.25)") do |f| %>
       <% if @packing_list.errors.any? %>
         <div class="bg-red-50 border-l-4 border-red-400 p-4 mb-6 rounded-lg">
           <div class="text-red-700">
@@ -89,7 +89,7 @@
           戻る
         <% end %>
 
-        <%= f.submit "登録する", class: "px-8 py-3 text-white rounded-full transition-all duration-300 shadow-sm hover:shadow flex items-center", style: "background-color: rgba(242, 210, 114, 0.75)" %>
+        <%= f.submit "登録する", class: "px-8 py-3 bg-[#FFB800] text-white rounded-full transition-all duration-300 shadow-sm hover:shadow flex items-center", style: "background-color:#FFB800" %>
       </div>
     <% end %>
   </div>

--- a/app/views/pages/task_selection.html.erb
+++ b/app/views/pages/task_selection.html.erb
@@ -1,4 +1,4 @@
-<div class="min-h-screen bg-white">
+<div class="min-h-screen bg-white pb-24">
   <div class="container mx-auto px-4 py-8">
     <div class="grid grid-cols-2 gap-6 max-w-3xl mx-auto">
       
@@ -22,10 +22,12 @@
         </div>
       <% end %>
     </div>
+  </div>
 
-    <!-- 戻るボタン -->
-    <div class="text-center mt-8">
-      <%= link_to root_path, class: "inline-flex items-center px-8 py-3 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 shadow-sm hover:shadow" do %>
+  <!-- 戻るボタン -->
+  <div class="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-sm shadow-lg p-4">
+    <div class="max-w-screen-xl mx-auto flex justify-center">
+      <%= link_to root_path, class: "px-8 py-3 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
         </svg>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -27,21 +27,24 @@
       </div>
     </div>
 
-    <div class="flex gap-2">
+    <div class="flex items-center space-x-2">
       <%= link_to edit_task_path(task),
           data: { turbo_frame: "modal" },
-          class: "inline-flex items-center px-3 py-1.5 rounded-full text-sm bg-pink-50 text-pink-500 hover:bg-pink-100 transition-colors duration-200" do %>
-        <i class="fas fa-edit mr-1.5"></i>
-        <span>編集</span>
+          class: "p-2 hover:bg-pink-50 rounded-lg transition-colors duration-200 flex items-center",
+          title: "編集" do %>
+        <svg class="h-5 w-5 text-pink-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+        </svg>
       <% end %>
 
       <%= button_to task_path(task),
           method: :delete,
           data: { turbo_confirm: "このタスクを削除してもよろしいですか？", turbo_frame: "_top" },
-          class: "inline-flex items-center px-3 py-1.5 rounded-full text-sm bg-red-50 text-red-500 hover:bg-red-100 transition-colors duration-200",
-          form: { class: "inline-block" } do %>
-        <i class="fas fa-trash-alt mr-1.5"></i>
-        <span>削除</span>
+          class: "p-2 hover:bg-red-50 rounded-lg transition-colors duration-200 flex items-center",
+          title: "削除" do %>
+        <svg class="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
       <% end %>
     </div>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,42 +1,93 @@
 <div class="pb-24 bg-white">
-  <div class="container mx-auto px-4">
+  <h1 class="text-3xl font-semibold text-center mb-8 text-red-400">タスク一覧</h1>
 
-    <h1 class="text-3xl font-semibold text-center mb-8 text-red-400">タスク一覧</h1>
+  <div class="max-w-3xl mx-auto px-4">
+    <!-- リスト -->
+    <div class="bg-white shadow-lg rounded-2xl overflow-hidden border mb-4" style="border-color: rgba(255, 99, 132, 0.25)">
+      <ul class="divide-y divide-gray-200">
+        <% @tasks.each do |task| %>
+          <li class="hover:bg-gray-50 transition-colors duration-200">
+            <div class="p-4 flex items-center justify-between">
+              <!-- チェックボックスとタスク内容 -->
+              <div class="flex items-center flex-1">
+                <%= form_with(model: task, data: { turbo_action: "replace" }, class: "flex items-center") do |f| %>
+                  <div class="mr-4">
+                    <%= f.check_box :completed,
+                        class: "h-6 w-6 rounded border-gray-300 focus:ring-2 cursor-pointer",
+                        style: "color: #FF6384",
+                        onchange: 'this.form.submit()' %>
+                  </div>
+                <% end %>
 
-    <div id="tasks" class="max-w-4xl mx-auto space-y-4 mb-8">
-      <% if @tasks.any? %>
-        <div class="grid grid-cols-1 gap-4">
-          <% @tasks.each do |task| %>
-            <div id="task_<%= task.id %>" class="task bg-white shadow-lg rounded-xl overflow-hidden transition-all duration-300 hover:shadow-xl border border-red-100">
-              <%= render partial: 'tasks/task', locals: { task: task } %>
+                <div class="flex-1">
+                  <p class="<%= task.completed ? 'line-through text-gray-400' : 'text-gray-800' %> font-medium text-lg">
+                    <%= task.title %>
+                  </p>
+                  
+                  <% if task.description.present? %>
+                    <p class="text-sm <%= task.completed ? 'line-through text-gray-400' : 'text-gray-600' %>">
+                      <%= task.description %>
+                    </p>
+                  <% end %>
+
+                  <div class="mt-1">
+                    <span class="inline-flex items-center px-2.5 py-1 rounded-full text-sm <%= task.completed ? 'bg-gray-100 text-gray-500' : (task.due_date&.past? ? 'bg-red-100 text-red-600' : 'bg-pink-100 text-pink-600') %>">
+                      <i class="far fa-calendar-alt mr-1.5"></i>
+                      <%= task.due_date&.strftime("%Y年%m月%d日") || '期限なし' %>
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              <!-- 編集・削除ボタン -->
+              <div class="flex items-center space-x-2">
+                <%= link_to edit_task_path(task),
+                    data: { turbo_frame: "modal" },
+                    class: "p-2 hover:bg-pink-50 rounded-lg transition-colors duration-200 flex items-center",
+                    title: "編集" do %>
+                  <svg class="h-5 w-5 text-pink-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                <% end %>
+
+                <%= button_to task_path(task),
+                    method: :delete,
+                    data: { turbo_confirm: "このタスクを削除してもよろしいですか？", turbo_frame: "_top" },
+                    class: "p-2 hover:bg-red-50 rounded-lg transition-colors duration-200 flex items-center",
+                    title: "削除" do %>
+                  <svg class="h-5 w-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                <% end %>
+              </div>
             </div>
-          <% end %>
-        </div>
-      <% else %>
-        <div class="text-center py-12 bg-red-50 rounded-xl border border-red-100">
-          <svg class="w-16 h-16 text-pink-200 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
-          </svg>
-          <p class="text-gray-500">タスクがありません。新規タスクを作成してください。</p>
-        </div>
-      <% end %>
+          </li>
+        <% end %>
+
+        <% if @tasks.empty? %>
+          <li class="text-center py-12 text-gray-500">
+            <p class="text-lg">タスクがありません</p>
+            <p class="mt-2">「新規タスク作成」から追加しましょう</p>
+          </li>
+        <% end %>
+      </ul>
     </div>
   </div>
 
   <%= turbo_frame_tag 'modal' %>
 </div>
 
-<!-- 固定フッターボタン -->
+<!-- フッターボタン -->
 <div class="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-sm shadow-lg p-4">
   <div class="max-w-screen-xl mx-auto flex justify-center space-x-4">
     <%= link_to task_selection_path, class: "px-8 py-3 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
-      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
       </svg>
       戻る
     <% end %>
     <%= link_to new_task_path, class: "px-8 py-3 bg-red-400 text-white rounded-full hover:bg-red-500 transition-all duration-300 shadow-sm hover:shadow flex items-center", data: { turbo_frame: 'modal' } do %>
-      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
       </svg>
       新規タスク作成

--- a/app/views/wigs/edit.html.erb
+++ b/app/views/wigs/edit.html.erb
@@ -53,7 +53,7 @@
 
         <!-- 更新ボタン -->
         <div class="flex flex-col items-center space-y-4 mt-12">
-          <%= form.submit "更新する", class: "w-full sm:w-2/3 px-8 py-4 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 text-center text-lg font-medium" %>
+          <%= form.submit "更新する", class: "w-full sm:w-2/3 px-8 py-4 bg-blue-400 text-white rounded-full hover:bg-blue-500 transition-all duration-300 text-center text-lg font-medium" %>
           
           <!-- 戻るボタン -->
           <div class="w-full flex justify-center mt-6">

--- a/app/views/wigs/index.html.erb
+++ b/app/views/wigs/index.html.erb
@@ -39,7 +39,7 @@
       </svg>
       戻る
     <% end %>
-    <%= link_to new_wig_path, class: "px-8 py-3 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
+    <%= link_to new_wig_path, class: "px-8 py-3 bg-blue-400 text-white rounded-full hover:bg-blue-500 transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
       </svg>

--- a/app/views/wigs/new.html.erb
+++ b/app/views/wigs/new.html.erb
@@ -54,7 +54,7 @@
             戻る
           <% end %>
 
-          <%= form.submit "登録する", class: "w-full sm:w-auto px-8 py-4 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 text-center text-lg font-medium" %>
+          <%= form.submit "登録する", class: "w-full sm:w-auto px-8 py-4 bg-blue-400 text-white rounded-full hover:bg-blue-500 transition-all duration-300 text-center text-lg font-medium" %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
- 「ウィッグ」「カラコン」のボタン色を各ページのメインカラーに統一

- 「やること」リストの一覧を、「持ち物」リストの見た目に統一

- 「やること」一覧の編集・削除ボタンにアイコンを設置

- 「やること」「持ち物」の選択ページの”戻る”ボタンを他ページ同様、下部に固定