### PR TITLE
アイテム未登録時の表示設定

### DIFF
--- a/app/views/contact_lenses/index.html.erb
+++ b/app/views/contact_lenses/index.html.erb
@@ -2,31 +2,40 @@
   <h1 class="text-3xl font-semibold text-center mb-8" style="color: rgba(244, 164, 137, 1)">カラコン一覧</h1>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 px-4 max-w-7xl mx-auto">
-    <% @contact_lenses.each do |contact_lens| %>
-      <div class="bg-white shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-xl" style="border: 1px solid rgba(244, 164, 137, 0.3)">
-        <!-- カラコンの画像 -->
-        <%= link_to edit_contact_lense_path(contact_lens) do %>
-          <% if contact_lens.image.present? %>
-            <%= image_tag contact_lens.image, alt: contact_lens.name, class: "w-full h-64 object-cover" %>
-          <% else %>
-            <div class="w-full h-64 flex items-center justify-center" style="background-color: rgba(244, 164, 137, 0.1)">
-              <svg class="w-16 h-16" style="color: rgba(244, 164, 137, 0.3)" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-              </svg>
-            </div>
+    <% if @contact_lenses.any? %>
+      <% @contact_lenses.each do |contact_lens| %>
+        <div class="bg-white shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-xl" style="border: 1px solid rgba(244, 164, 137, 0.3)">
+          <!-- カラコンの画像 -->
+          <%= link_to edit_contact_lense_path(contact_lens) do %>
+            <% if contact_lens.image.present? %>
+              <%= image_tag contact_lens.image, alt: contact_lens.name, class: "w-full h-64 object-cover" %>
+            <% else %>
+              <div class="w-full h-64 flex items-center justify-center" style="background-color: rgba(244, 164, 137, 0.1)">
+                <svg class="w-16 h-16" style="color: rgba(244, 164, 137, 0.3)" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                </svg>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
 
-        <!-- カラコンの情報 -->
-        <div class="p-4">
-          <%= link_to edit_contact_lense_path(contact_lens), class: "group" do %>
-            <h2 class="text-xl font-medium text-gray-800 group-hover:text-[#F4A489] transition-colors duration-200">
-              <%= contact_lens.name %>
-            </h2>
-            <p class="text-sm text-gray-600 mt-2">
-              <span class="font-medium">使用期限:</span> <%= format_month_year(contact_lens.expiration_date) %>
-            </p>
-          <% end %>
+          <!-- カラコンの情報 -->
+          <div class="p-4">
+            <%= link_to edit_contact_lense_path(contact_lens), class: "group" do %>
+              <h2 class="text-xl font-medium text-gray-800 group-hover:text-[#F4A489] transition-colors duration-200">
+                <%= contact_lens.name %>
+              </h2>
+              <p class="text-sm text-gray-600 mt-2">
+                <span class="font-medium">使用期限:</span> <%= format_month_year(contact_lens.expiration_date) %>
+              </p>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="col-span-full text-center py-12 text-gray-500">
+        <div class="bg-white shadow-lg rounded-2xl p-8 border border-pink-100">
+          <p class="text-lg font-medium">まだ衣装が登録されていません</p>
+          <p class="mt-2 text-gray-400">「新規登録」から衣装を登録しましょう</p>
         </div>
       </div>
     <% end %>

--- a/app/views/costumes/index.html.erb
+++ b/app/views/costumes/index.html.erb
@@ -2,28 +2,37 @@
   <h1 class="text-3xl font-semibold text-center mb-8 text-pink-400">衣装一覧</h1>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 px-4 max-w-7xl mx-auto">
-    <% @costumes.each do |costume| %>
-      <div class="bg-white shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-xl border border-pink-100">
-        <!-- 衣装の画像 -->
-        <%= link_to edit_costume_path(costume) do %>
-          <% if costume.image.present? %>
-            <%= image_tag costume.image, alt: costume.character_name, class: "w-full h-64 object-cover" %>
-          <% else %>
-            <div class="w-full h-64 bg-pink-50 flex items-center justify-center">
-              <svg class="w-16 h-16 text-pink-200" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-              </svg>
-            </div>
+    <% if @costumes.any? %>
+      <% @costumes.each do |costume| %>
+        <div class="bg-white shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-xl border border-pink-100">
+          <!-- 衣装の画像 -->
+          <%= link_to edit_costume_path(costume) do %>
+            <% if costume.image.present? %>
+              <%= image_tag costume.image, alt: costume.character_name, class: "w-full h-64 object-cover" %>
+            <% else %>
+              <div class="w-full h-64 bg-pink-50 flex items-center justify-center">
+                <svg class="w-16 h-16 text-pink-200" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                </svg>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
 
-        <!-- キャラクター名 -->
-        <div class="p-4">
-          <%= link_to edit_costume_path(costume), class: "group" do %>
-            <h2 class="text-xl font-medium text-gray-800 group-hover:text-pink-400 transition-colors duration-200">
-              <%= costume.character_name %>
-            </h2>
-          <% end %>
+          <!-- キャラクター名 -->
+          <div class="p-4">
+            <%= link_to edit_costume_path(costume), class: "group" do %>
+              <h2 class="text-xl font-medium text-gray-800 group-hover:text-pink-400 transition-colors duration-200">
+                <%= costume.character_name %>
+              </h2>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="col-span-full text-center py-12 text-gray-500">
+        <div class="bg-white shadow-lg rounded-2xl p-8 border border-pink-100">
+          <p class="text-lg font-medium">まだ衣装が登録されていません</p>
+          <p class="mt-2 text-gray-400">「新規登録」から衣装を登録しましょう</p>
         </div>
       </div>
     <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -63,4 +63,15 @@
       <% end %>
     </div>
   </div>
+
+  <!-- フッター -->
+  <footer class="bg-white-800 text-gray py-6 mt-auto">
+    <div class="container mx-auto text-center">
+      <ul class="space-y-4 sm:space-y-0 sm:flex sm:space-x-6 sm:justify-center">
+        <li><%= link_to "利用規約", "#", class: "hover:underline text-gray-600" %></li>
+        <li><%= link_to "お問い合わせ", "#", class: "hover:underline text-gray-600" %></li>
+        <li><%= link_to "プライバシーポリシー", "#", class: "hover:underline text-gray-600" %></li>
+      </ul>
+    </div>
+  </footer>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,15 +39,5 @@
       <%= yield %>
       <%= turbo_frame_tag 'modal' %>
     </div>
-
-    <footer class="bg-white-800 text-gray py-6">
-      <div class="container mx-auto text-center">
-        <ul class="space-y-4 sm:space-y-0 sm:flex sm:space-x-6 sm:justify-center">
-          <li><%= link_to "利用規約", "#", class: "hover:underline" %></li>
-          <li><%= link_to "お問い合わせ", "#", class: "hover:underline" %></li>
-          <li><%= link_to "プライバシーポリシー", "#", class: "hover:underline" %></li>
-        </ul>
-      </div>
-    </footer>
   </body>
 </html>

--- a/app/views/wigs/index.html.erb
+++ b/app/views/wigs/index.html.erb
@@ -2,28 +2,37 @@
   <h1 class="text-3xl font-semibold text-center mb-8 text-blue-400">ウィッグ一覧</h1>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 px-4 max-w-7xl mx-auto">
-    <% @wigs.each do |wig| %>
-      <div class="bg-white shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-xl border border-blue-100">
-        <!-- ウィッグの画像 -->
-        <%= link_to edit_wig_path(wig) do %>
-          <% if wig.image.present? %>
-            <%= image_tag wig.image, alt: wig.character_name, class: "w-full h-64 object-cover" %>
-          <% else %>
-            <div class="w-full h-64 bg-blue-50 flex items-center justify-center">
-              <svg class="w-16 h-16 text-blue-200" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-              </svg>
-            </div>
+    <% if @wigs.any? %>
+      <% @wigs.each do |wig| %>
+        <div class="bg-white shadow-lg rounded-2xl overflow-hidden transition-all duration-300 hover:scale-105 hover:shadow-xl border border-blue-100">
+          <!-- ウィッグの画像 -->
+          <%= link_to edit_wig_path(wig) do %>
+            <% if wig.image.present? %>
+              <%= image_tag wig.image, alt: wig.character_name, class: "w-full h-64 object-cover" %>
+            <% else %>
+              <div class="w-full h-64 bg-blue-50 flex items-center justify-center">
+                <svg class="w-16 h-16 text-blue-200" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                </svg>
+              </div>
+            <% end %>
           <% end %>
-        <% end %>
 
-        <!-- キャラクター名 -->
-        <div class="p-4">
-          <%= link_to edit_wig_path(wig), class: "group" do %>
-            <h2 class="text-xl font-medium text-gray-800 group-hover:text-blue-400 transition-colors duration-200">
-              <%= wig.character_name %>
-            </h2>
-          <% end %>
+          <!-- キャラクター名 -->
+          <div class="p-4">
+            <%= link_to edit_wig_path(wig), class: "group" do %>
+              <h2 class="text-xl font-medium text-gray-800 group-hover:text-blue-400 transition-colors duration-200">
+                <%= wig.character_name %>
+              </h2>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="col-span-full text-center py-12 text-gray-500">
+        <div class="bg-white shadow-lg rounded-2xl p-8 border border-blue-100">
+          <p class="text-lg font-medium">まだウィッグが登録されていません</p>
+          <p class="mt-2 text-gray-400">「新規登録」からウィッグを登録しましょう</p>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
- 「衣装」「ウィッグ」「カラコン」が未登録の際、各一覧画面に "まだ〇〇が登録されていません" "「新規登録」から〇〇を登録しましょう" の表示を行う。

- 全画面にフッターの「利用規約」「お問い合わせ」「プライバシーポリシー」の表示があり可視性に欠けていたので、TOPページにのみ表示するように変更。