### PR TITLE
やること機能の修正

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -21,11 +21,11 @@ class TasksController < ApplicationController
     if @task.save
       respond_to do |format|
         format.turbo_stream do
+          @tasks = current_user.tasks.reload
           render turbo_stream: [
             turbo_stream.update("tasks-container",
               partial: "tasks/task",
-              collection: Task.all,
-              as: :task
+              collection: @tasks
             ),
             turbo_stream.remove("modal")
           ]

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -11,7 +11,7 @@ export default class extends Controller {
     if (event) {
       event.preventDefault()
     }
-    this.element.remove() // モーダル要素を完全に削除
+    this.element.remove()
   }
 
   closeBackground(event) {

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,9 @@
 class Task < ApplicationRecord
   belongs_to :user
 
+  default_scope { order(created_at: :desc) }
+  scope :user_tasks, ->(user) { where(user: user) }
+
   validates :title, presence: true, length: { maximum: 50, message: "は50文字以内で入力してください" }
   validates :description, length: { maximum: 200, message: "は200文字以内で入力してください" }
 


### PR DESCRIPTION
「やること」機能で、タスク作成後他のUserのタスクが見えてしまう件を修正。

***

- 作成後の動きを`collection: Task.all`から`collection: @tasks`に変更。

- モデルでも、ログインしているユーザーが自身のタスクのみ閲覧できるようにした。