### PR TITLE
プロフィール設定機能

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,28 @@
+class ProfilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_profile, only: [:show, :edit, :update]
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+    if @profile.update(profile_params)
+      redirect_to @profile, notice: 'プロフィールを更新しました'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def set_profile
+    @profile = current_user.profile || current_user.build_profile
+  end
+
+  def profile_params
+    params.require(:profile).permit(:handle_name, :image, :activity, :location, :genre, :message)
+  end
+end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,0 +1,2 @@
+module ProfilesHelper
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,0 +1,8 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+
+  enum activity: { no_activity: 0, layer:1, camera: 2 }
+
+  has_one_attached :image
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,5 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :tasks, dependent: :destroy
   has_many :packing_lists, dependent: :destroy
+  has_one :profile, dependent: :destroy
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -52,8 +52,8 @@
         </div>
       <% end %>
 
-      <!-- 設定ボタン -->
-      <%= link_to "#", class: "transform hover:scale-105 transition-transform duration-300" do %>
+      <!-- プロフィール設定ボタン -->
+      <%= link_to profile_path, class: "transform hover:scale-105 transition-transform duration-300" do %>
         <div class="setting-button">
           <div class="flex flex-col items-center space-y-3 p-4 border-4 border-gray-300 rounded-xl">
             <%= image_tag "icons/setting.svg", class: "h-12 w-12" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,56 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="max-w-2xl mx-auto bg-white rounded-lg shadow-lg p-6">
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">プロフィール編集</h1>
+      <%= link_to "戻る", profile_path, class: "text-gray-600 hover:text-gray-800" %>
+    </div>
+
+    <%= form_with(model: @profile, url: profile_path, method: :patch, local: true) do |f| %>
+      <% if @profile.errors.any? %>
+        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+          <ul>
+            <% @profile.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <div class="space-y-6">
+        <div>
+          <%= f.label :handle_name, "コスネーム", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.text_field :handle_name, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        </div>
+
+        <div>
+          <%= f.label :image, "プロフィール画像", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.file_field :image, class: "mt-1 block w-full" %>
+        </div>
+
+        <div>
+          <%= f.label :activity, "活動タイプ", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.select :activity, Profile.activities.keys.map { |k| [k.titleize, k] }, { include_blank: "選択してください" }, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        </div>
+
+        <div>
+          <%= f.label :location, "活動地域", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.text_field :location, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        </div>
+
+        <div>
+          <%= f.label :genre, "ジャンル", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.text_field :genre, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        </div>
+
+        <div>
+          <%= f.label :message, "ひとこと", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.text_area :message, rows: 4, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        </div>
+
+        <div class="flex justify-end">
+          <%= f.submit "更新する", class: "bg-blue-500 text-white px-6 py-2 rounded hover:bg-blue-600" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,46 @@
+<div class="container mx-auto px-4 py-8">
+  <div class="max-w-2xl mx-auto bg-white rounded-lg shadow-lg p-6">
+    <% if notice %>
+      <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+        <span class="block sm:inline"><%= notice %></span>
+      </div>
+    <% end %>
+
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold">マイプロフィール</h1>
+      <%= link_to "編集", edit_profile_path, class: "bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" %>
+    </div>
+
+    <div class="flex items-center space-x-4 mb-6">
+      <% if @profile.image.present? %>
+        <%= image_tag @profile.image.url, class: "w-32 h-32 rounded-full object-cover" %>
+      <% else %>
+        <div class="w-32 h-32 bg-gray-200 rounded-full flex items-center justify-center">
+          <span class="text-gray-500">No Image</span>
+        </div>
+      <% end %>
+      
+      <div>
+        <h2 class="text-xl font-bold"><%= @profile.handle_name.presence || "未設定" %></h2>
+        <p class="text-gray-600"><%= @profile.activity.presence || "未設定" %></p>
+      </div>
+    </div>
+
+    <div class="space-y-4">
+      <div>
+        <h3 class="font-semibold text-gray-700">活動地域</h3>
+        <p><%= @profile.location.presence || "未設定" %></p>
+      </div>
+
+      <div>
+        <h3 class="font-semibold text-gray-700">ジャンル</h3>
+        <p><%= @profile.genre.presence || "未設定" %></p>
+      </div>
+
+      <div>
+        <h3 class="font-semibold text-gray-700">ひとこと</h3>
+        <p><%= @profile.message.presence || "未設定" %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,5 +30,5 @@ Rails.application.routes.draw do
   resources :contact_lenses, except: [:show]
   resources :articles
   resources :packing_lists
-  resources :settings
+  resource :profile, only: [:show, :edit, :update]
 end

--- a/db/migrate/20250403063620_create_profiles.rb
+++ b/db/migrate/20250403063620_create_profiles.rb
@@ -1,0 +1,15 @@
+class CreateProfiles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :profiles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :handle_name
+      t.string :image
+      t.integer :activity, default: 0
+      t.string :location
+      t.string :genre
+      t.text :message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_27_003313) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_03_063620) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -96,6 +96,19 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_27_003313) do
     t.index ["user_id"], name: "index_packing_lists_on_user_id"
   end
 
+  create_table "profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "handle_name"
+    t.string "image"
+    t.integer "activity", default: 0
+    t.string "location"
+    t.string "genre"
+    t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_profiles_on_user_id"
+  end
+
   create_table "tasks", force: :cascade do |t|
     t.string "title", null: false
     t.string "description"
@@ -138,6 +151,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_27_003313) do
   add_foreign_key "contact_lenses", "users"
   add_foreign_key "costumes", "users"
   add_foreign_key "packing_lists", "users"
+  add_foreign_key "profiles", "users"
   add_foreign_key "tasks", "users"
   add_foreign_key "wigs", "users"
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfilesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  handle_name: MyString
+  image: MyString
+  activity: 1
+  location: MyString
+  genre: MyString
+  message: MyText
+
+two:
+  user: two
+  handle_name: MyString
+  image: MyString
+  activity: 1
+  location: MyString
+  genre: MyString
+  message: MyText

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ProfileTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
ユーザーに紐づいたプロフィールの設定機能の大まかな枠組みを作成。

***

- TOPページ「設定」より遷移

- プロフィール未設定の場合は、自動作成する。

- 作成したカラム（各項目にバリデーションは無し）

> 
> handle_name　コスネーム
> image　　　　  画像
> activity　　　   設定なしorレイヤーorカメラ（enum）
> location　　　  活動地域
> genre　　　　  ジャンル
> message　　　ひとこと