### PR TITLE
プロフィール編集とビュー

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,54 +1,91 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="max-w-2xl mx-auto bg-white rounded-lg shadow-lg p-6">
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">プロフィール編集</h1>
-      <%= link_to "戻る", profile_path, class: "text-gray-600 hover:text-gray-800" %>
-    </div>
+<div class="min-h-screen bg-white pb-24">
+  <div class="max-w-2xl mx-auto px-4 py-8">
+    <h1 class="text-3xl font-semibold text-center mb-8 text-purple-400">プロフィール編集</h1>
 
-    <%= form_with(model: @profile, url: profile_path, method: :patch, local: true) do |f| %>
-      <% if @profile.errors.any? %>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-          <ul>
-            <% @profile.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
+    <%= form_with(model: @profile, url: profile_path, method: :patch, local: true, class: "space-y-6") do |f| %>
+      <div class="bg-white p-8 rounded-2xl shadow-lg border border-purple-100">
+        <% if @profile.errors.any? %>
+          <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-6" role="alert">
+            <strong class="font-bold">エラーがあります：</strong>
+            <ul class="mt-2 list-disc list-inside">
+              <% @profile.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
 
-      <div class="space-y-6">
-        <div>
-          <%= f.label :handle_name, "コスネーム", class: "block text-sm font-medium text-gray-700" %>
-          <%= f.text_field :handle_name, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
-        </div>
-
-        <div>
-          <%= f.label :image, "プロフィール画像", class: "block text-sm font-medium text-gray-700" %>
-          <%= f.file_field :image, class: "mt-1 block w-full" %>
-        </div>
-
-        <div>
-          <%= f.label :activity, "活動タイプ", class: "block text-sm font-medium text-gray-700" %>
-          <%= f.select :activity, Profile.activities.keys.map { |k| [k.titleize, k] }, { include_blank: "選択してください" }, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
-        </div>
-
-        <div>
-          <%= f.label :location, "活動地域", class: "block text-sm font-medium text-gray-700" %>
-          <%= f.text_field :location, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        <!-- プロフィール画像 -->
+        <div class="mb-8">
+          <%= f.label :image, "プロフィール画像", class: "block text-gray-700 font-medium mb-2" %>
+          <div class="flex items-center justify-center w-full">
+            <label class="w-full flex flex-col items-center px-4 py-6 bg-purple-50 text-purple-500 rounded-lg border-2 border-purple-200 border-dashed cursor-pointer hover:bg-purple-100 transition-colors duration-300">
+              <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+              </svg>
+              <span class="mt-2 text-sm">クリックして画像を変更</span>
+              <%= f.file_field :image, class: "hidden", accept: "image/*" %>
+            </label>
+          </div>
+          
+          <% if @profile.image.present? %>
+            <div class="mt-4 flex justify-center">
+              <%= image_tag @profile.image, class: "w-32 h-32 rounded-full object-cover" %>
+            </div>
+          <% end %>
         </div>
 
-        <div>
-          <%= f.label :genre, "ジャンル", class: "block text-sm font-medium text-gray-700" %>
-          <%= f.text_field :genre, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        <!-- 基本情報 -->
+        <div class="mb-8">
+          <%= f.label :handle_name, "コスネーム", class: "block text-gray-700 font-medium mb-2" %>
+          <div class="input-wrapper">
+            <%= f.text_field :handle_name, class: "w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent", placeholder: "コスネームを入力" %>
+          </div>
         </div>
 
-        <div>
-          <%= f.label :message, "ひとこと", class: "block text-sm font-medium text-gray-700" %>
-          <%= f.text_area :message, rows: 4, class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        <div class="mb-8">
+          <%= f.label :activity, "活動タイプ", class: "block text-gray-700 font-medium mb-2" %>
+          <div class="input-wrapper">
+            <%= f.select :activity,
+              Profile.activities.keys.map { |k| [t("activerecord.attributes.profile.activity.#{k}"), k] },
+                { include_blank: "選択してください" },
+                class: "w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent" %>
+          </div>
         </div>
 
-        <div class="flex justify-end">
-          <%= f.submit "更新する", class: "bg-blue-500 text-white px-6 py-2 rounded hover:bg-blue-600" %>
+        <div class="mb-8">
+          <%= f.label :location, "活動地域", class: "block text-gray-700 font-medium mb-2" %>
+          <div class="input-wrapper">
+            <%= f.text_field :location, class: "w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent", placeholder: "例：東京都" %>
+          </div>
+        </div>
+
+        <div class="mb-8">
+          <%= f.label :genre, "ジャンル", class: "block text-gray-700 font-medium mb-2" %>
+          <div class="input-wrapper">
+            <%= f.text_field :genre, class: "w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent", placeholder: "例：アニメ、ゲーム" %>
+          </div>
+        </div>
+
+        <div class="mb-8">
+          <%= f.label :message, "ひとこと", class: "block text-gray-700 font-medium mb-2" %>
+          <div class="input-wrapper">
+            <%= f.text_area :message, rows: 4, class: "w-full px-4 py-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent", placeholder: "自己紹介やアピールポイントを書いてください" %>
+          </div>
+        </div>
+
+        <div class="flex flex-col items-center space-y-4 mt-12">
+          <%= f.submit "更新する", class: "w-full sm:w-2/3 px-8 py-4 bg-purple-400 text-white rounded-full hover:bg-purple-500 transition-all duration-300 text-center text-lg font-medium" %>
+        </div>
+
+        <!-- 戻るボタン -->
+        <div class="w-full flex justify-center mt-6">
+          <%= link_to profile_path, class: "px-8 py-4 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            </svg>
+          戻る
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,45 +1,75 @@
-<div class="container mx-auto px-4 py-8">
-  <div class="max-w-2xl mx-auto bg-white rounded-lg shadow-lg p-6">
+<div class="min-h-screen bg-gray-50 pb-24">
+  <div class="max-w-2xl mx-auto px-4 py-8">
     <% if notice %>
-      <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+      <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded-lg mb-6" role="alert">
         <span class="block sm:inline"><%= notice %></span>
       </div>
     <% end %>
 
-    <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">マイプロフィール</h1>
-      <%= link_to "編集", edit_profile_path, class: "bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600" %>
-    </div>
+    <div class="bg-white rounded-2xl shadow-lg p-8 border border-purple-100">
+      <!-- ヘッダー -->
+      <div class="flex justify-between items-center mb-8">
+        <h1 class="text-3xl font-bold text-purple-400">マイプロフィール</h1>
+        <%= link_to edit_profile_path, class: "px-4 py-2 bg-purple-400 text-white rounded-full hover:bg-purple-500 transition-all duration-300 shadow-sm hover:shadow flex items-center text-sm" do %>
+          <svg class="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+          </svg>
+          編集
+        <% end %>
+      </div>
 
-    <div class="flex items-center space-x-4 mb-6">
-      <% if @profile.image.present? %>
-        <%= image_tag @profile.image.url, class: "w-32 h-32 rounded-full object-cover" %>
-      <% else %>
-        <div class="w-32 h-32 bg-gray-200 rounded-full flex items-center justify-center">
-          <span class="text-gray-500">No Image</span>
+      <!-- プロフィール画像とハンドルネーム -->
+      <div class="flex flex-col items-center mb-8">
+        <div class="mb-4">
+          <% if @profile.image.present? %>
+            <%= image_tag @profile.image, class: "w-40 h-40 rounded-full object-cover border-4 border-purple-100 shadow-lg" %>
+          <% else %>
+            <div class="w-40 h-40 bg-purple-50 rounded-full flex items-center justify-center border-4 border-purple-100">
+              <span class="text-purple-300 text-lg">No Image</span>
+            </div>
+          <% end %>
         </div>
-      <% end %>
-      
-      <div>
-        <h2 class="text-xl font-bold"><%= @profile.handle_name.presence || "未設定" %></h2>
-        <p class="text-gray-600"><%= @profile.activity.presence || "未設定" %></p>
+        
+        <h2 class="text-4xl font-bold text-gray-600"><%= @profile.handle_name.presence || "未設定" %></h2>
+      </div>
+
+      <!-- 詳細情報 -->
+      <div class="space-y-6 bg-purple-50 rounded-xl p-6">
+        <div class="grid grid-cols-1 gap-6">
+          <div class="border-b border-purple-100 pb-4">
+            <h3 class="text-sm font-medium text-purple-400 mb-2">活動タイプ</h3>
+            <p class="text-gray-700 text-lg">
+              <%= t("activerecord.attributes.profile.activity.#{@profile.activity}") %>
+            </p>
+          </div>
+
+          <div class="border-b border-purple-100 pb-4">
+            <h3 class="text-sm font-medium text-purple-400 mb-2">活動地域</h3>
+            <p class="text-gray-700 text-lg"><%= @profile.location.presence || "未設定" %></p>
+          </div>
+
+          <div class="border-b border-purple-100 pb-4">
+            <h3 class="text-sm font-medium text-purple-400 mb-2">ジャンル</h3>
+            <p class="text-gray-700 text-lg"><%= @profile.genre.presence || "未設定" %></p>
+          </div>
+
+          <div>
+            <h3 class="text-sm font-medium text-purple-400 mb-2">ひとこと</h3>
+            <p class="text-gray-700 text-lg"><%= @profile.message.presence || "未設定" %></p>
+          </div>
+        </div>
       </div>
     </div>
 
-    <div class="space-y-4">
-      <div>
-        <h3 class="font-semibold text-gray-700">活動地域</h3>
-        <p><%= @profile.location.presence || "未設定" %></p>
-      </div>
-
-      <div>
-        <h3 class="font-semibold text-gray-700">ジャンル</h3>
-        <p><%= @profile.genre.presence || "未設定" %></p>
-      </div>
-
-      <div>
-        <h3 class="font-semibold text-gray-700">ひとこと</h3>
-        <p><%= @profile.message.presence || "未設定" %></p>
+    <!-- 戻るボタン -->
+    <div class="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur-sm shadow-lg p-4">
+      <div class="max-w-screen-xl mx-auto flex justify-center">
+        <%= link_to root_path, class: "px-8 py-3 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 shadow-sm hover:shadow flex items-center" do %>
+          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+          </svg>
+          戻る
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -5,6 +5,8 @@ ja:
         status: 状態
       wig:
         status: 状態
+      profile:
+        activity: 活動タイプ
     attributes:
       costume:
         status:
@@ -14,3 +16,8 @@ ja:
         status:
           completed: 完成
           incomplete: 未完成
+      profile:
+        activity:
+          no_activity: ー
+          layer: コスプレイヤー
+          camera: カメラマン


### PR DESCRIPTION
プロフィール編集機能の作成とプロフィール機能全体の見た目を整える

***

- 下記項目の編集と更新ができる

> handle_name コスネーム
> image　　   　画像
> activity　　　その他orレイヤーorカメラ（enum）
> location　　   活動地域
> genre　　  　ジャンル
> message　　ひとこと

- 他のページに合わせた見た目に変更

- activityに日本語化設定