### PR TITLE
プロフィール画像をヘッダーに設置

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,11 @@
         <!-- ユーザーアイコン -->
         <div class="relative">
           <button class="bg-white-600 rounded-full p-2">
-            <%= image_tag 'default_user_icon.png', alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full" %>
+            <% if current_user&.profile&.image&.attached? %>
+              <%= image_tag current_user.profile.image, alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full object-cover" %>
+            <% else %>
+              <%= image_tag 'default_user_icon.png', alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full" %>
+            <% end %>
           </button>
         </div>
       </div>


### PR DESCRIPTION
ヘッダーのユーザーアイコンに、プロフィールで設定した画像を表示する。

***

- ログイン後、プロフィールに画像が設定されている場合は、ヘッダーに画像を表示
- 未ログインや、画像未設定の場合はデフォルト画像を表示