### PR TITLE
アカウント削除機能

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -70,6 +70,13 @@
       </svg>
       ログアウト
     <% end %>
+
+    <%= button_to user_registration_path, method: :delete, data: { turbo_confirm: "本当にアカウントを削除しますか？この操作は取り消せません。" }, class: "px-6 py-3 bg-red-50 text-red-600 rounded-xl hover:bg-red-100 transition-all duration-300 shadow-sm hover:shadow flex items-center justify-center" do %>
+      <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+      </svg>
+      アカウント削除
+    <% end %>
   </div>
 </div>
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -35,7 +35,7 @@ ja:
       send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
       send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
     failure:
-      already_authenticated: すでにログインしています。
+      already_authenticated: ログインしました。
       inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
       invalid: "%{authentication_keys}またはパスワードが違います。"
       last_attempt: もう一回誤るとアカウントがロックされます。
@@ -90,7 +90,7 @@ ja:
       updated: パスワードが正しく変更されました。
       updated_not_active: パスワードが正しく変更されました。
     registrations:
-      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      destroyed: アカウントを削除しました。
       edit:
         are_you_sure: 本当によろしいですか？
         cancel_my_account: アカウント削除
@@ -114,7 +114,7 @@ ja:
       updated: アカウント情報を変更しました。
       updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
     sessions:
-      already_signed_out: 既にログアウト済みです。
+      already_signed_out: ログアウトしました。
       new:
         sign_in: ログイン
       signed_in: ログインしました。


### PR DESCRIPTION
deviseを使用したアカウントの削除機能の実装

- 「設定」→「アカウント管理」にアカウント削除ボタンを設置
- アカウント削除時は確認ダイアログを表示
- deviseのフラッシュメッセージの文章を変更