### PR TITLE
カラコンの検索機能

### DIFF
--- a/app/models/contact_lens.rb
+++ b/app/models/contact_lens.rb
@@ -9,11 +9,31 @@ class ContactLens < ApplicationRecord
   validate :image_content_type
   validate :image_size
 
-    def image_content_type
-      if image.attached? && !image.content_type.in?(%w[image/jpeg image/png])
-        errors.add(:image, 'ファイルの形式はJPEGまたはPNGである必要があります。')
-      end
+  def self.ransackable_attributes(auth_object = nil)
+    %w[name expiration_date]
+  end
+
+  scope :with_expiration_date, ->(date_str) {
+    return none unless date_str.present? && date_str.match?(/\A\d{4}-\d{2}\z/)
+    
+    year, month = date_str.split('-').map(&:to_i)
+    begin
+      target_date = Date.new(year, month, 1)
+      where(expiration_date: target_date)
+    rescue Date::Error
+      none
     end
+  }
+
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
+  def image_content_type
+    if image.attached? && !image.content_type.in?(%w[image/jpeg image/png])
+      errors.add(:image, 'ファイルの形式はJPEGまたはPNGである必要があります。')
+    end
+  end
 
   def image_size
     if image.attached? && image.byte_size > 5.megabytes

--- a/app/models/costume.rb
+++ b/app/models/costume.rb
@@ -13,6 +13,10 @@ class Costume < ApplicationRecord
     %w[character_name status]
   end
 
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
   def image_content_type
     if image.attached? && !image.content_type.in?(%w[image/jpeg image/png])
       errors.add(:image, 'ファイルの形式はJPEGまたはPNGである必要があります。')

--- a/app/models/wig.rb
+++ b/app/models/wig.rb
@@ -12,6 +12,10 @@ class Wig < ApplicationRecord
     %w[character_name status]
   end
 
+  def self.ransackable_associations(auth_object = nil)
+    []
+  end
+
   def image_content_type
     if image.attached? && !image.content_type.in?(%w[image/jpeg image/png])
       errors.add(:image, 'ファイルの形式はJPEGまたはPNGである必要があります。')

--- a/app/views/contact_lenses/edit.html.erb
+++ b/app/views/contact_lenses/edit.html.erb
@@ -73,21 +73,20 @@
             <% end %>
           </div>
         </div>
-
-        <!-- 削除ボタン -->
-        <div class="w-full border-t border-gray-200 mt-8 pt-8">
-          <div class="text-center text-sm text-gray-600 mb-4">削除する場合は以下のボタンを押してください</div>
-          <%= button_to contact_lense_path(@contact_lens), 
-              method: :delete,
-              data: { confirm: '本当に削除しますか？' },
-              class: "w-full sm:w-2/3 mx-auto px-8 py-4 bg-red-400 text-white rounded-full hover:bg-red-500 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-            </svg>
-            削除する
-          <% end %>
-        </div>
       </div>
     <% end %>
+
+    <!-- 削除ボタン -->
+    <div class="w-full border-t border-gray-200 mt-8 pt-8">
+      <div class="text-center text-sm text-gray-600 mb-4">削除する場合は以下のボタンを押してください</div>
+      <%= button_to contact_lense_path(@contact_lens), 
+          method: :delete,
+          data: { confirm: '本当に削除しますか？' },
+          class: "w-full sm:w-2/3 mx-auto px-8 py-4 bg-red-400 text-white rounded-full hover:bg-red-500 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+        削除する
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/contact_lenses/index.html.erb
+++ b/app/views/contact_lenses/index.html.erb
@@ -1,5 +1,33 @@
 <div class="pb-24">
   <h1 class="text-3xl font-semibold text-center mb-8" style="color: rgba(244, 164, 137, 1)">カラコン一覧</h1>
+  <div class="max-w-5xl mx-auto mb-8 px-4">
+    <%= search_form_for @q, url: search_contact_lenses_path, html: { class: "bg-white rounded-lg shadow-sm p-6 border", style: "border-color: rgba(244, 164, 137, 0.3)" } do |f| %>
+      <div class="flex flex-wrap items-end gap-4">
+        <div class="flex-grow min-w-[200px]">
+          <%= f.label :name_cont, "カラコン名で検索", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.search_field :name_cont, 
+              placeholder: "カラコン名を入力",
+              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-[#F4A489] focus:ring focus:ring-[#F4A489] focus:ring-opacity-50 px-4 py-2" 
+          %>
+        </div>
+
+        <div class="w-40">
+          <%= f.label :expiration_date_gteq, "使用期限", class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.text_field :expiration_date_gteq, 
+              type: 'month',
+              placeholder: "YYYY-MM",
+              class: "w-full rounded-md border-gray-300 shadow-sm focus:border-[#F4A489] focus:ring focus:ring-[#F4A489] focus:ring-opacity-50 px-4 py-2"
+          %>
+        </div>
+
+        <div>
+          <%= f.submit "検索", 
+              class: "px-8 py-2 bg-[#F4A489] text-white rounded-full hover:bg-[#f59577] transition-all duration-300 shadow-sm hover:shadow h-[42px] flex items-center justify-center" 
+          %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 px-4 max-w-7xl mx-auto">
     <% if @contact_lenses.any? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,11 @@ Rails.application.routes.draw do
       get 'search', to: 'wigs#search', as: 'search'
     end
   end
-  resources :contact_lenses, except: [:show]
+  resources :contact_lenses, except: [:show] do
+    collection do
+      get 'search', to: 'contact_lenses#search', as: 'search'
+    end
+  end
   resources :articles
   resources :packing_lists
   resource :profile, only: [:show, :edit, :update]


### PR DESCRIPTION
登録済みカラコンの検索機能を実装

- カラコン名の部分一致検索
- 使用期限（年月）の完全一致検索

***
また、以下の修正を行った。

- カラコン更新ボタンが削除機能になっていたので、ビューを修正。
- 衣装・ウィッグの検索における、アソシエーションを設定。（関連付けられたモデルの検索対策）