### PR TITLE
カラコン一覧ページ修正

### DIFF
--- a/app/views/contact_lenses/index.html.erb
+++ b/app/views/contact_lenses/index.html.erb
@@ -62,8 +62,8 @@
     <% else %>
       <div class="col-span-full text-center py-12 text-gray-500">
         <div class="bg-white shadow-lg rounded-2xl p-8 border border-pink-100">
-          <p class="text-lg font-medium">まだ衣装が登録されていません</p>
-          <p class="mt-2 text-gray-400">「新規登録」から衣装を登録しましょう</p>
+          <p class="text-lg font-medium">まだカラコンが登録されていません</p>
+          <p class="mt-2 text-gray-400">「新規登録」からカラコンを登録しましょう</p>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
カラコン未登録の際に「まだ衣装が登録されていません」「衣装を登録しましょう」となっていたので、カラコンに修正。