### PR TITLE
未ログイン時の記事閲覧不可を修正

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,15 +4,7 @@ class ArticlesController < ApplicationController
 
   def index
     @q = Article.ransack(params[:q])
-    @articles = if params[:q].present?
-                  if params[:q]&.dig(:user_id_eq) == current_user.id.to_s
-                    @q.result(distinct: true)
-                  else
-                    @q.result(distinct: true)
-                  end
-                else
-                  Article.all
-                end
+    @articles = params[:q].present? ? @q.result(distinct: true) : Article.all
   end
 
   def show

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -7,13 +7,15 @@
             placeholder: "タイトルで検索", 
             class: "w-full px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-green-200" %>
       </div>
-      <div class="flex items-center">
-        <%= f.check_box :user_id_eq, 
-            { class: "mr-2" }, 
-            current_user.id, 
-            nil %>
-        <%= f.label :user_id_eq, "自分の記事のみ表示", class: "text-gray-700" %>
-      </div>
+      <% if user_signed_in? %>
+        <div class="flex items-center">
+          <%= f.check_box :user_id_eq, 
+              { class: "mr-2" }, 
+              current_user.id, 
+              nil %>
+          <%= f.label :user_id_eq, "自分の記事のみ表示", class: "text-gray-700" %>
+        </div>
+      <% end %>
       <%= f.submit "検索", 
           class: "px-6 py-2 text-white rounded-lg transition-all duration-300",
           style: "background-color: rgba(126, 199, 143, 0.9); hover:background-color: rgba(126, 199, 143, 1)" %>


### PR DESCRIPTION
未ログイン時、記事の閲覧が不可になっているエラーの解決。

- 記事検索機能を実装した際に、自分の記事を絞り込む機能を追加したことが原因
- ビューで、サインインしていれば「自分の記事のみ表示」というボタンを表示
- indexの処理を三項演算子を使用した形に変更