### PR TITLE
お問い合わせページの実装

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -1,0 +1,4 @@
+class ContactsController < ApplicationController
+  def new
+  end
+end

--- a/app/helpers/contacts_helper.rb
+++ b/app/helpers/contacts_helper.rb
@@ -1,0 +1,2 @@
+module ContactsHelper
+end

--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -1,0 +1,6 @@
+<div class="container mx-auto px-4 py-8">
+  
+  <div class="w-full">
+  <iframe src="https://docs.google.com/forms/d/e/1FAIpQLScA00XtK3T3WRl6g9uD3T4eWBkV9TyZwFmqaGUXIlqovBA0zQ/viewform?embedded=true" width="100%" height="800px" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -69,7 +69,7 @@
     <div class="container mx-auto text-center">
       <ul class="space-y-4 sm:space-y-0 sm:flex sm:space-x-6 sm:justify-center">
         <li><%= link_to "利用規約", "#", class: "hover:underline text-gray-600" %></li>
-        <li><%= link_to "お問い合わせ", "#", class: "hover:underline text-gray-600" %></li>
+        <li><%= link_to "お問い合わせ", contact_path, class: "hover:underline text-gray-600" %></li>
         <li><%= link_to "プライバシーポリシー", "#", class: "hover:underline text-gray-600" %></li>
       </ul>
     </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,13 @@ module Myapp
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.action_dispatch.default_headers = {
+      "Content-Security-Policy" => "frame-ancestors 'self' https://docs.google.com/; frame-src 'self' https://docs.google.com/",
+      "X-Content-Type-Options" => 'nosniff",
+      "X-XSS-Protection" => "1; mode=block",
+      "Referrer-Policy" => "strict-origin-when-cross-origin"
+    }
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get 'task_selection', to: 'pages#task_selection'
+  get 'contact', to: 'contacts#new'
 
   resources :tasks do
     member do

--- a/test/controllers/contacts_controller_test.rb
+++ b/test/controllers/contacts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ContactsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
「お問い合わせ」の実装

- TOPページのフッター「お問い合わせ」から遷移
- Googleフォームで作成
  - 名前（任意）
  - メールアドレス（返信が必要な場合のみ）
  - お問い合わせの種類
  - 内容
- `config/application.rb` にセキュリティ設定
  - 不正なiframeの埋め込み防止
  - スニッフィング防止
  - XSS 攻撃からの防御