### PR TITLE
articleモデルテストとエラー箇所修正

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -8,6 +8,11 @@ class Article < ApplicationRecord
   end
   has_many :bookmarks, dependent: :destroy
 
+  validates :title, presence: true, length: { maximum: 100, message: "は100文字以内で入力してください" }
+
+  validate :content_presence
+  validate :content_length_within_limit
+
   def self.ransackable_attributes(auth_object = nil)
     %w[title user_id]
   end
@@ -16,6 +21,17 @@ class Article < ApplicationRecord
     []
   end
 
-  validates :title, presence: true, length: { maximum: 100, message: "は100文字以内で入力してください" }
-  validates :content, presence: true, length: { maximum: 10000, message: "は10000文字以内で入力してください" }
+  private
+
+  def content_presence
+    if content.blank? || content.to_plain_text.blank?
+      errors.add(:content, "を入力してください")
+    end
+  end
+
+  def content_length_within_limit
+    if content.present? && content.to_plain_text.length > 10_000
+      errors.add(:content, "は10000文字以内で入力してください")
+    end
+  end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -21,3 +21,7 @@ ja:
           no_activity: ー
           layer: コスプレイヤー
           camera: カメラマン
+    errors:
+      messages:
+        blank: "を入力してください"
+        too_long: "は%{count}文字以内で入力してください"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,7 +1,21 @@
 FactoryBot.define do
   factory :article do
     title { Faker::Lorem.sentence }
-    content { Faker::Lorem.paragraph }
+    
+    after(:build) do |article|
+      article.content = ActionText::Content.new(Faker::Lorem.paragraph(sentence_count: 3))
+    end
+
     association :user
+
+    trait :with_featured_image do
+      after(:build) do |article|
+        article.featured_image.attach(
+          io: File.open(Rails.root.join('spec', 'fixtures', 'files', 'test.jpeg')),
+          filename: 'test.jpeg',
+          content_type: 'image/jpeg'
+        )
+      end
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Article, type: :model do
+  describe 'バリデーション' do
+    subject { build(:article) }
+
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to have_rich_text(:content) }
+    it { is_expected.to have_one_attached(:featured_image) }
+    it { is_expected.to have_many(:bookmarks).dependent(:destroy) }
+
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_length_of(:title).is_at_most(100).with_message('は100文字以内で入力してください') }  
+  end
+
+  describe 'contentのバリデーション' do
+    let(:article) { build(:article) }
+
+    context 'contentが空の場合' do
+      before { article.content = nil }
+
+      it 'バリデーションエラーになる' do
+        article.content = ActionText::Content.new("")
+        article.valid?
+        expect(article.errors[:content]).to include("を入力してください")
+      end
+
+      context 'contentが10000文字を超える場合' do
+        before { article.content = 'a' * 10001 }
+
+        it 'バリデーションエラーになる' do
+          article.valid?
+          expect(article.errors[:content]).to include("は10000文字以内で入力してください")
+        end
+      end
+
+      context 'contentが10000文字以内の場合' do
+        before { article.content = 'a' * 10000 }
+
+        it 'バリデーションエラーにならない' do
+          expect(article).to be_valid
+        end
+      end
+    end
+  end
+
+  describe '添付画像のバリデーション' do
+    let(:article) { create(:article, :with_featured_image) }
+
+    it '画像が正常に添付される' do
+      expect(article.featured_image).to be_attached
+    end
+
+    it 'バリアントが正常に作成される' do
+      expect(article.featured_image.variant(:thumb).processed).to be_present
+      expect(article.featured_image.variant(:medium).processed).to be_present
+      expect(article.featured_image.variant(:large).processed).to be_present
+    end
+  end
+
+  describe 'ransackable_attributes' do
+    it 'ransack によって使用可能な属性を返す' do
+      expect(Article.ransackable_attributes).to match_array(%w[title user_id])
+    end
+  end
+
+  describe 'ransackable_associations' do
+    it '空の配列を返すこと' do
+      expect(Article.ransackable_associations).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
articleモデルのテストコードを記述→テスト実施
[![Image from Gyazo](https://i.gyazo.com/fb64411713cc97ac084614f1f7fcc829.png)](https://gyazo.com/fb64411713cc97ac084614f1f7fcc829)

- `ja.yml` にエラーメッセージを追加

- Article モデルの content のバリデーションの書き方を変更
`has_rich_text `を使用しているから。