### PR TITLE
ヘルプページの修正

### DIFF
--- a/app/views/helps/index.html.erb
+++ b/app/views/helps/index.html.erb
@@ -133,7 +133,7 @@
 
 <!-- JavaScript（アコーディオン制御） -->
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('turbo:load', () => {
     const buttons = document.querySelectorAll('.accordion-toggle');
 
     buttons.forEach(button => {


### PR DESCRIPTION
ヘルプページ遷移後にリロードしないとトグルの開閉ができないことを解決