### PR TITLE
新規登録ボタン位置の変更

### DIFF
--- a/app/views/contact_lenses/edit.html.erb
+++ b/app/views/contact_lenses/edit.html.erb
@@ -81,7 +81,7 @@
       <div class="text-center text-sm text-gray-600 mb-4">削除する場合は以下のボタンを押してください</div>
       <%= button_to contact_lense_path(@contact_lens), 
           method: :delete,
-          data: { confirm: '本当に削除しますか？' },
+          data: { turbo_confirm: '本当に削除しますか？' },
           class: "w-full sm:w-2/3 mx-auto px-8 py-4 bg-red-400 text-white rounded-full hover:bg-red-500 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>          <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
         </svg>

--- a/app/views/contact_lenses/new.html.erb
+++ b/app/views/contact_lenses/new.html.erb
@@ -58,15 +58,18 @@
         </div>
 
         <!-- ボタン -->
-        <div class="flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-6 mt-12">
-          <%= link_to contact_lenses_path, class: "w-full sm:w-auto px-8 py-4 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-            </svg>
-            戻る
-          <% end %>
+        <div class="flex flex-col items-center space-y-4 mt-12">
+          <%= form.submit "登録する", class: "w-full sm:w-2/3 px-8 py-4 bg-[#F4A489] text-white rounded-full hover:bg-[#f59577] transition-all duration-300 text-center text-lg font-medium" %>
 
-          <%= form.submit "登録する", class: "w-full sm:w-auto px-8 py-4 bg-[#F4A489] text-white rounded-full hover:bg-[#f59577] transition-all duration-300 text-center text-lg font-medium" %>
+          <!-- 戻るボタン -->
+          <div class="w-full flex justify-center mt-6">
+            <%= link_to contact_lenses_path, class: "px-8 py-4 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
+              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+              </svg>
+              戻る
+            <% end %>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/costumes/edit.html.erb
+++ b/app/views/costumes/edit.html.erb
@@ -77,7 +77,7 @@
       <div class="text-center text-sm text-gray-600 mb-4">削除する場合は以下のボタンを押してください</div>
       <%= button_to costume_path(@costume),
         method: :delete,
-        data: { confirm: '本当に削除しますか？' },
+        data: { turbo_confirm: '本当に削除しますか？' },
         class: "w-full sm:w-2/3 mx-auto px-8 py-4 bg-red-400 text-white rounded-full hover:bg-red-500 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/app/views/costumes/new.html.erb
+++ b/app/views/costumes/new.html.erb
@@ -53,15 +53,18 @@
         </div>
 
         <!-- ボタン -->
-        <div class="flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-6 mt-12">
-          <%= link_to costumes_path, class: "w-full sm:w-auto px-8 py-4 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-            </svg>
-            戻る
-          <% end %>
+        <div class="flex flex-col items-center space-y-4 mt-12">
+          <%= form.submit "登録する", class: "w-full sm:w-2/3 px-8 py-4 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 text-center text-lg font-medium" %>
 
-          <%= form.submit "登録する", class: "w-full sm:w-auto px-8 py-4 bg-pink-400 text-white rounded-full hover:bg-pink-500 transition-all duration-300 text-center text-lg font-medium" %>
+          <!-- 戻るボタン -->
+          <div class="w-full flex justify-center mt-6">
+            <%= link_to costumes_path, class: "px-8 py-4 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
+              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+              </svg>
+              戻る
+            <% end %>
+          </div>
         </div>
       </div>
     <% end %>

--- a/app/views/wigs/edit.html.erb
+++ b/app/views/wigs/edit.html.erb
@@ -77,7 +77,7 @@
       <div class="text-center text-sm text-gray-600 mb-4">削除する場合は以下のボタンを押してください</div>
       <%= button_to wig_path(@wig),
           method: :delete,
-          data: { confirm: '本当に削除しますか？' },
+          data: { turbo_confirm: '本当に削除しますか？' },
           class: "w-full sm:w-2/3 mx-auto px-8 py-4 bg-red-400 text-white rounded-full hover:bg-red-500 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
         <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/app/views/wigs/new.html.erb
+++ b/app/views/wigs/new.html.erb
@@ -53,15 +53,18 @@
         </div>
 
         <!-- ボタン -->
-        <div class="flex flex-col sm:flex-row justify-center items-center space-y-4 sm:space-y-0 sm:space-x-6 mt-12">
-          <%= link_to wigs_path, class: "w-full sm:w-auto px-8 py-4 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-            </svg>
-            戻る
-          <% end %>
+        <div class="flex flex-col items-center space-y-4 mt-12">
+          <%= form.submit "登録する", class: "w-full sm:w-2/3 px-8 py-4 bg-blue-400 text-white rounded-full hover:bg-blue-500 transition-all duration-300 text-center text-lg font-medium" %>
 
-          <%= form.submit "登録する", class: "w-full sm:w-auto px-8 py-4 bg-blue-400 text-white rounded-full hover:bg-blue-500 transition-all duration-300 text-center text-lg font-medium" %>
+          <!-- 戻るボタン -->
+          <div class="w-full flex justify-center mt-6">
+            <%= link_to wigs_path, class: "px-8 py-4 bg-gray-100 text-gray-600 rounded-full hover:bg-gray-200 transition-all duration-300 text-center flex items-center justify-center text-lg font-medium" do %>
+              <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+              </svg>
+              戻る
+            <% end %>
+          </div>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
costume/wig/contact_lensの新規登録ボタンの位置を変更

各項目の更新ページと同じようにした。

***

上記項目の削除時に「本当に削除しますか」確認ダイアログを表示できるように修正。

Rails7以降は `turbo_confirm` を使用する。