### PR TITLE
持ち物のエラーメッセージを修正

### DIFF
--- a/app/models/packing_list.rb
+++ b/app/models/packing_list.rb
@@ -2,12 +2,14 @@ class PackingList < ApplicationRecord
   belongs_to :user
   belongs_to :itemable, polymorphic: true, optional: true
 
-  validates :item, presence: true, unless: :itemable_present?
+  validate :item_or_itemable_present
   validates :item, length: { maximum: 50, message: 'は50文字以内で入力してください' }, if: :item?
 
   private
 
-  def itemable_present?
-    itemable.present? && itemable_id.present?
+  def item_or_itemable_present
+    if item.blank? && itemable_id.blank?
+      errors.add(:base, 'アイテム名を入力、または関連アイテムを選択してください')
+    end
   end
 end

--- a/app/views/packing_lists/new.html.erb
+++ b/app/views/packing_lists/new.html.erb
@@ -6,7 +6,7 @@
       <% if @packing_list.errors.any? %>
         <div class="bg-red-50 border-l-4 border-red-400 p-4 mb-6 rounded-lg">
           <div class="text-red-700">
-            <h2><%= pluralize(@packing_list.errors.count, "error") %> prohibited this item from being saved:</h2>
+            <h2><%= @packing_list.errors.count %>件のエラーが発生しました</h2>
             <ul class="list-disc pl-5">
               <% @packing_list.errors.full_messages.each do |message| %>
                 <li><%= message %></li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -7,6 +7,7 @@ ja:
         status: 状態
       profile:
         activity: 活動タイプ
+      packing_list: 持ち物リスト
     attributes:
       costume:
         status:
@@ -21,7 +22,15 @@ ja:
           no_activity: ー
           layer: コスプレイヤー
           camera: カメラマン
+      packing_list:
+        item: "アイテム名"
+        itemable: "関連アイテム名"
     errors:
       messages:
-        blank: "を入力してください"
+        blank: "この項目を入力してください"
         too_long: "は%{count}文字以内で入力してください"
+      models:
+        packing_list:
+          attributes:
+            base:
+              item_or_itemable_present: "アイテム名を入力、または関連アイテムを選択してください"


### PR DESCRIPTION
持ち物リスト作成時のバリデーションエラーメッセージを日本語に修正

[![Image from Gyazo](https://i.gyazo.com/b9e432aa5b30d458fd96eae4e81fac0a.png)](https://gyazo.com/b9e432aa5b30d458fd96eae4e81fac0a)