### PR TITLE
ヘッダーアイコンの変更

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,27 +38,59 @@
           <%= image_tag 'coschest_logo.png', alt: "COSchestロゴ", class: "h-8 w-auto" %>
         <% end %>
 
-        <div class="flex items-center space-x-4">
+        <div class="flex items-center space-x-6">
           <!-- ヘルプページ -->
-          <%= link_to help_path, class: "text-gray-600 hover:text-gray-800" do %>
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          <% end %>
+          <div class="relative group">
+            <%= link_to help_path, class: "text-gray-600 hover:text-gray-800 flex flex-col items-center min-h-[52px]" do %>
+              <div class="flex items-center justify-center p-3">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              </div>
+              <!-- スマホ用ラベル -->
+              <span class="text-xs md:hidden">ヘルプ</span>
+              <!-- PC用ツールチップ -->
+              <div class="hidden md:block absolute invisible group-hover:visible bg-gray-800 text-white text-sm py-1 px-3 rounded-md -bottom-10 left-1/2 transform -translate-x-1/2 whitespace-nowrap z-50">
+                ヘルプページ
+                <!-- フキダシ -->
+                <div class="absolute -top-1 left-1/2 transform -translate-x-1/2 w-2 h-2 bg-gray-800 rotate-45"></div>
+              </div>
+            <% end %>
+          </div>
 
           <!-- ユーザーアイコン -->
-          <div class="relative">
+          <div class="relative group">
             <% if current_user %>
-              <%= link_to profile_path, class: "bg-white-600 rounded-full p-2 block" do %>
-                <% if current_user&.profile&.image&.attached? %>
-                  <%= image_tag current_user.profile.image, alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full object-cover" %>
-                <% else %>
-                  <%= image_tag 'default_user_icon.png', alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full" %>
-                <% end %>
+              <%= link_to profile_path, class: "flex flex-col items-center min-h-[52px]" do %>
+                <div class="flex items-center justify-center p-2">
+                  <% if current_user&.profile&.image&.attached? %>
+                    <%= image_tag current_user.profile.image, alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full object-cover" %>
+                  <% else %>
+                    <%= image_tag 'default_user_icon.png', alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full" %>
+                  <% end %>
+                </div>
+                <!-- スマホ用ラベル -->
+                <span class="text-xs md:hidden">プロフィール</span>
+                <!-- PC用ツールチップ -->
+                <div class="hidden md:block absolute invisible group-hover:visible bg-gray-800 text-white text-sm py-1 px-3 rounded-md -bottom-10 left-1/2 transform -translate-x-1/2 whitespace-nowrap z-50">
+                  プロフィール編集
+                  <!-- フキダシ -->
+                  <div class="absolute -top-1 left-1/2 transform -translate-x-1/2 w-2 h-2 bg-gray-800 rotate-45"></div>
+                </div>
               <% end %>
             <% else %>
-              <%= link_to new_user_session_path, class: "bg-white-600 rounded-full p-2 block" do %>
-                <%= image_tag 'default_user_icon.png', alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full" %>
+              <%= link_to new_user_session_path, class: "flex flex-col items-center" do %>
+                <div class="flex items-center justify-center p-2">
+                  <%= image_tag 'default_user_icon.png', alt: "ユーザーアイコン", class: "h-8 w-8 rounded-full" %>
+                </div>
+                <!-- スマホ用ラベル -->
+                <span class="text-xs md:hidden">ログイン</span>
+                <!-- PC用ツールチップ -->
+                <div class="hidden md:block absolute invisible group-hover:visible bg-gray-800 text-white text-sm py-1 px-3 rounded-md -bottom-10 left-1/2 transform -translate-x-1/2 whitespace-nowrap z-50">
+                  ログイン
+                  <!-- フキダシ -->
+                  <div class="absolute -top-1 left-1/2 transform -translate-x-1/2 w-2 h-2 bg-gray-800 rotate-45"></div>
+                </div>
               <% end %>
             <% end %>
           </div>


### PR DESCRIPTION
ヘッダーの「ヘルプ」「ユーザー」のアイコンに各機能の見出しを追加。

- PC用、スマホ用に設定
- PC用はカーソルを合わせると「ヘルプページ」「プロフィール設定」と表示
- スマホ用は各アイコンの下部に「ヘルプ」「プロフィール」と表示
[![Image from Gyazo](https://i.gyazo.com/f524176777b09b38fa7c3794b8228aed.png)](https://gyazo.com/f524176777b09b38fa7c3794b8228aed)