### PR TITLE
画像ファイル名の表示

### DIFF
--- a/app/views/my_photos/new.html.erb
+++ b/app/views/my_photos/new.html.erb
@@ -47,7 +47,7 @@
                   onchange: "document.getElementById('file-name').textContent = this.files[0].name;" %>
             </label>
           </div>
-          <div class="mt-4 text-sm text-gray-600 text-center" id="file-list"></div>
+          <div class="mt-4 text-sm text-gray-600 text-center" id="file-name"></div>
         </div>
 
         <!-- タイトル -->

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -24,10 +24,15 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
               <span class="mt-2 text-sm">クリックして画像を変更</span>
-              <%= f.file_field :image, class: "hidden", accept: "image/*" %>
+              <%= f.file_field :image,
+                  class: "hidden",
+                  accept: "image/*",
+                  onchange: "document.getElementById('profile-file-name').textContent = this.files[0].name;" %>
             </label>
           </div>
-          
+
+          <div class="mt-4 text-sm text-gray-600 text-center" id="profile-file-name"></div>
+
           <% if @profile.image.present? %>
             <div class="mt-4 flex justify-center">
               <%= image_tag @profile.image, class: "w-32 h-32 rounded-full object-cover" %>


### PR DESCRIPTION
マイフォト・プロフィールの画像投稿時に選択ファイル名を表示する

衣装・ウィッグ・カラコンは、選択ファイル名が表示されるのに、マイフォト・プロフィールの画像には表示されなかった件を改善。